### PR TITLE
fix(packaging): MANIFEST.in path; restore v0.1.x history; add AUTOLOAD-SETUP doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,100 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ## [0.2.0] - 2026-04-27
 
-Initial public release of **mindkeep**.
+The Big Rename. The project's working title was `agent-memory`; its final identity is **`mindkeep`**. This release renames the PyPI package, the CLI command, the importable Python module, and the GitHub repository. There are no functional changes to the storage layer, CLI surface, or on-disk record format — only identifiers.
+
+### Changed
+
+- **BREAKING — Project renamed `agent-memory` → `mindkeep`.** The PyPI package (`mindkeep`), the CLI command (`mindkeep`), the importable Python module (`mindkeep`), and the GitHub repository (now [`AllenS0104/mindkeep`](https://github.com/AllenS0104/mindkeep)) have all been renamed in lockstep. The legacy `agent-memory` distribution is no longer published.
+- **BREAKING — Environment variables renamed:**
+  - `AGENT_MEMORY_HOME` → `MINDKEEP_HOME`
+  - `AGENT_MEMORY_UPGRADE_SOURCE` → `MINDKEEP_UPGRADE_SOURCE`
+  - `AGENT_MEMORY_NO_CONFIRM` → `MINDKEEP_NO_CONFIRM`
+- **BREAKING — Default data directory renamed `agent-memory/` → `mindkeep/`** under the platform-specific application-data root (`%APPDATA%`, `~/Library/Application Support`, `$XDG_DATA_HOME`). Existing v0.1.x users will see an empty store on first launch unless they manually copy or move the contents of the old `agent-memory/` directory into the new `mindkeep/` directory.
+
+### Migration
+
+```bash
+pipx uninstall agent-memory
+pipx install mindkeep
+mindkeep doctor
+```
+
+If you have existing v0.1.x data, copy it across before first use, e.g. on Linux:
+
+```bash
+mv "$XDG_DATA_HOME/agent-memory" "$XDG_DATA_HOME/mindkeep"
+```
+
+(or the equivalent path on macOS / Windows). If you scripted the legacy environment variables in shells, CI, or agent runners, rename them to the `MINDKEEP_*` forms above.
+
+---
+
+## [0.1.2] - 2026-04-24
+
+### Fixed
+
+- **Repository URL identity** — corrected all references from the legacy `v-songjun/mindkeep` path to the canonical `AllenS0104/mindkeep` across install scripts, README, CLI output, release notes, and test fixtures. Previous versions pointed installers at a non-existent repository.
+
+### Changed
+
+- **README version alignment** — bumped install/raw URLs and pinned-version examples to `v0.1.2`; restated the v0.1.1 LF-normalization fix for install scripts.
+
+---
+
+## [0.1.1] - 2026-04-24
+
+### Fixed
+
+- **Install scripts line endings** — normalized `install.ps1` and `install.sh` to LF via `.gitattributes` (`text eol=lf`). On Windows clones with `core.autocrlf=true`, v0.1.0's `install.ps1` was checked out as CRLF, but `raw.githubusercontent.com` serves the stored LF bytes. This caused `SHA256SUMS` (computed on the CRLF working copy) to fail verification against the raw URL. v0.1.1 guarantees a single canonical byte stream across local clone, raw URL, and Release asset.
+
+### Changed
+
+- `SHA256SUMS` is now computed on LF-normalized bytes and is itself stored with LF line endings.
+
+---
+
+## [0.1.0] - 2026-04-24
+
+First public release — a crash-safe, per-project long-term memory store for AI coding agents.
 
 ### Added
 
-- Crash-safe per-project long-term memory store (`MemoryStore`) backed by SQLite + WAL.
-- Public API: `add_fact` / `remember_fact` / `list_facts` / `recall_facts`, `add_adr` / `remember_adr` / `list_adrs` / `recall_adrs`, plus retention scheduler.
-- CLI: `mindkeep` (init, fact, adr, list, gc, doctor, version).
-- Installers: `install.ps1` (Windows) and `install.sh` (macOS / Linux), pure-Python wheel, sdist.
-- Pure-Python wheel, **zero runtime dependencies**, Python ≥ 3.9, MIT licensed.
-- 159-test suite covering CLI, storage, scheduler, security, integration, and crash-recovery scenarios.
+- **Core `MemoryStore`** with WAL-mode SQLite backend, 30 s flush scheduler, `atexit` / `SIGTERM` hooks, and atomic `.meta.json` rename for crash safety.
+- **Per-project isolation** — one SQLite DB per repo, keyed by `sha256(git-remote || abs-path)[:12]`.
+- **Global preferences store** (`preferences.db`) for user-level tastes that follow you across projects.
+- **Four record types**: facts, ADRs, preferences, sessions — each with tags and timestamps.
+- **CLI with 9 subcommands**: `list`, `show`, `clear`, `export`, `import`, `where`, `doctor`, `upgrade`, plus `--version`.
+  - `doctor` — environment health check (Python version, PATH, `data_dir`, WAL support, redactor, project detection).
+  - `upgrade` — auto-detects `pipx` vs `pip` and reinstalls from the configured source; supports `--dry-run`.
+- **JSON export / import** for portable, diffable backups.
+- **Install scripts** — `install.sh` (macOS/Linux) and `install.ps1` (Windows) with Python ≥ 3.9 check, auto-`pipx` bootstrap, `PATH` update, and post-install `doctor` invocation.
+- **pipx-first distribution** — published as a standard wheel + sdist; `pipx install` is the recommended path.
+- **Cross-platform `data_dir` resolution** — `%APPDATA%` (Windows), `~/Library/Application Support` (macOS), `$XDG_DATA_HOME` (Linux), overridable via `$MINDKEEP_HOME`.
+- **Python ≥ 3.9 support** with zero runtime dependencies (stdlib only).
 
-### Notes
+### Security
 
-mindkeep v0.2.0 is a rebrand of the legacy `agent-memory` v0.1.5 codebase. Public API surface is identical except for renames documented in `RELEASE-NOTES.md`. Legacy source, tags, and release artifacts (v0.1.0 – v0.1.5) have been archived privately at `AllenS0104/mindkeep-archive`.
+- **SQL column-name whitelist (P0)** — all dynamic ORDER BY / column references are validated against a fixed allowlist to eliminate the injection surface.
+- **`SecretsRedactor` with 11 built-in patterns** — scrubs PEM private keys, JWTs, GitHub PATs (classic + fine-grained), AWS access & secret keys, Google API keys, Slack tokens, OpenAI keys, Azure storage keys, plus a generic `password|token|api_key=…` sweep before write.
+- **`SHA256SUMS` published with every release** — wheel, sdist and install scripts are hash-verifiable.
+- **`install.sh` `main()` wrapper** — the curl | bash pipe only executes after the full script is received, preventing truncated-download code execution.
+- **CI hardening** — explicit least-privilege `permissions:` blocks on all GitHub Actions workflows.
+
+### Documentation
+
+- **`docs/INSTALL.md`** — 4 install methods (one-liner, pipx, pip, offline wheel) + enterprise / air-gapped flows + `doctor` diagnostics.
+- **`docs/USAGE.md`** — full CLI reference, Python API guide, and 8 cookbook recipes.
+- **`docs/UNINSTALL.md`** — backup, removal, PATH restoration and enterprise compliance exit checklist.
+- **`docs/FAQ.md`** — 22 questions across 5 categories (getting started, usage, security, internals, troubleshooting).
+- **`docs/TROUBLESHOOTING.md`** — 19 symptoms in a 4-section format (symptom / cause / diagnose / fix).
+- **`docs/README.md`** — documentation portal with role-based and task-based navigation.
+- **`CHANGELOG.md`** — this file (Keep a Changelog format).
+
+---
+
+[Unreleased]: https://github.com/AllenS0104/mindkeep/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/AllenS0104/mindkeep/releases/tag/v0.2.0
+[0.1.2]: https://github.com/AllenS0104/mindkeep/releases/tag/v0.1.2
+[0.1.1]: https://github.com/AllenS0104/mindkeep/releases/tag/v0.1.1
+[0.1.0]: https://github.com/AllenS0104/mindkeep/releases/tag/v0.1.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include README.md
 include ARCHITECTURE.md
 include LICENSE
 include pyproject.toml
-recursive-include src/agent_memory *.py py.typed
+recursive-include src/mindkeep *.py py.typed
 recursive-exclude tests *
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -1,0 +1,64 @@
+# 下一步（由你执行）
+
+所有本地构建与验证已完成。以下命令由你亲自运行，agent 不代劳（保留凭据与最终确认权）。
+
+## 1. 创建 GitHub 仓库并 push
+
+```powershell
+cd $env:REPO_ROOT
+
+# 如未登录
+gh auth login
+
+# 创建远程仓库并 push main
+gh repo create AllenS0104/mindkeep --public --source=. --push
+
+# push tag
+git push origin v0.1.0
+```
+
+## 2. 创建 Release 并上传产物
+
+```powershell
+cd $env:REPO_ROOT
+
+gh release create v0.1.0 `
+  dist/mindkeep-0.1.0-py3-none-any.whl `
+  dist/mindkeep-0.1.0.tar.gz `
+  dist/SHA256SUMS `
+  --title "v0.1.0" `
+  --notes-file RELEASE-NOTES.md
+```
+
+## 3. 验证 share 链接（仓库 public 之后）
+
+```powershell
+# Windows
+iwr https://raw.githubusercontent.com/AllenS0104/mindkeep/main/install.ps1 | iex
+```
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/AllenS0104/mindkeep/main/install.sh | bash
+```
+
+安装完成后：
+```bash
+mindkeep --version    # -> mindkeep 0.1.0
+mindkeep doctor       # -> All checks passed 🎉
+```
+
+## 4. 分享
+
+把 `SHARE.md` 内容直接粘贴到 IM 发给朋友即可。
+
+---
+
+## 产物校验码 (SHA256)
+
+```
+494ca7f9b497aa288c86d86c869c08c71ac5cb84d652acb747771e5b4513deb5  mindkeep-0.1.0-py3-none-any.whl
+43c1f95e86dd3c1cce66ba70d7104fd5099f91218e0ec8f76382a816fb888590  mindkeep-0.1.0.tar.gz
+```
+
+（与 `dist/SHA256SUMS` 一致）

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,0 +1,152 @@
+# 发布到 GitHub 的步骤（首次）
+
+> **状态（v0.1.0, release-v0.1.0 todo 完成后）**
+> - ✅ 154 / 154 tests green
+> - ✅ `mindkeep --version` = 0.1.0
+> - ✅ `mindkeep doctor` = All checks passed 🎉
+> - ✅ `dist/mindkeep-0.1.0-py3-none-any.whl` 已构建
+> - ✅ `dist/mindkeep-0.1.0.tar.gz` 已构建
+> - ✅ `dist/SHA256SUMS` 已生成（见下）
+> - ✅ 所有 hotfix 已 commit（install.ps1 pipx、security P1、upgrade regression、README、CI）
+> - ✅ Tag `v0.1.0` 已打在本地
+> - ⏭️ 下一步见 [`NEXT-STEPS.md`](./NEXT-STEPS.md) — 由你执行 `gh repo create` / `gh release create`
+>
+> **实际 SHA256（来自 `dist/SHA256SUMS`）**
+> ```
+> 494ca7f9b497aa288c86d86c869c08c71ac5cb84d652acb747771e5b4513deb5  mindkeep-0.1.0-py3-none-any.whl
+> 43c1f95e86dd3c1cce66ba70d7104fd5099f91218e0ec8f76382a816fb888590  mindkeep-0.1.0.tar.gz
+> ```
+
+本文档由 `github-repo-bootstrap` todo 生成。仓库已在本地 `git init` 并完成首次 commit；
+以下步骤由**你本人**执行，agent 不代劳（保留凭据与最终确认权）。
+
+## 前置条件
+
+- 已安装 [GitHub CLI](https://cli.github.com/): `gh --version`
+- 在仓库根目录（`<repo-root>`）下
+
+## 1. 登录 GitHub（如未登录）
+
+```powershell
+gh auth status
+# 如未登录：
+gh auth login
+```
+
+## 2. 创建远端仓库并 push
+
+```powershell
+cd $env:REPO_ROOT
+gh repo create AllenS0104/mindkeep --public --source=. --push
+```
+
+这会：
+- 在 `github.com/AllenS0104/mindkeep` 创建公开仓库
+- 将当前目录设为 source
+- 把本地 `main` 分支 push 上去
+
+## 3. 构建发布产物并创建 Release
+
+```powershell
+# 构建 wheel 和 sdist
+python -m pip install --upgrade build
+python -m build
+
+# 创建 v0.1.0 release 并上传产物
+gh release create v0.1.0 dist/*.whl dist/*.tar.gz `
+  --title "v0.1.0" `
+  --notes "First public release of mindkeep. Stdlib-only, SQLite/WAL cross-project memory store for AI agents."
+```
+
+## 3.1 Release 产物哈希（SHA256SUMS）
+
+> **为什么**：一键安装（`curl | bash` / `iwr | iex`）本质是执行远端代码。发布哈希让用户可以核对下载内容未被篡改，是供应链安全的基础防线。
+
+对每次 Release，构建完产物后生成 `SHA256SUMS`，随 wheel / sdist / 安装脚本一并上传；并把哈希粘到 Release notes。
+
+### Windows (PowerShell)
+
+```powershell
+cd $env:REPO_ROOT
+# 对发布产物 + 安装脚本一起计算
+$files = @(
+  "dist\mindkeep-0.1.0-py3-none-any.whl",
+  "dist\mindkeep-0.1.0.tar.gz",
+  "install.ps1",
+  "install.sh"
+)
+$files | ForEach-Object {
+  $h = (Get-FileHash -Algorithm SHA256 $_).Hash.ToLower()
+  "$h  $(Split-Path -Leaf $_)"
+} | Set-Content -Encoding ascii SHA256SUMS
+
+Get-Content SHA256SUMS
+```
+
+### macOS / Linux (bash)
+
+```bash
+cd mindkeep
+sha256sum dist/*.whl dist/*.tar.gz install.ps1 install.sh > SHA256SUMS
+cat SHA256SUMS
+```
+
+### 上传并写入 Release notes
+
+```powershell
+# 把 SHA256SUMS 追加到现有 release
+gh release upload v0.1.0 SHA256SUMS
+
+# 或在 create 时一并带上
+gh release create v0.1.0 dist/*.whl dist/*.tar.gz install.ps1 install.sh SHA256SUMS `
+  --title "v0.1.0" `
+  --notes-file RELEASE_NOTES.md
+```
+
+在 Release notes 里加一节，示例：
+
+````markdown
+## 🔐 SHA256 checksums
+
+```
+<粘贴 SHA256SUMS 内容>
+```
+
+Verify before running:
+
+```powershell
+# Windows
+iwr https://github.com/AllenS0104/mindkeep/releases/download/v0.1.0/install.ps1 -OutFile install.ps1
+Get-FileHash -Algorithm SHA256 install.ps1
+```
+
+```bash
+# macOS / Linux
+curl -fsSL -o install.sh https://github.com/AllenS0104/mindkeep/releases/download/v0.1.0/install.sh
+curl -fsSL -o SHA256SUMS https://github.com/AllenS0104/mindkeep/releases/download/v0.1.0/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+```
+````
+
+## 4. 验证一键安装链接
+
+share/install 脚本（由 `install-ps1` todo 产生）发布后应可通过 raw URL 访问：
+
+```powershell
+iwr https://raw.githubusercontent.com/AllenS0104/mindkeep/main/install.ps1 | iex
+```
+
+确认：
+- 链接返回 200
+- 脚本可成功安装 `mindkeep` CLI
+- `mindkeep --version` 输出 `0.1.0`
+
+## 回滚 / 重做
+
+```powershell
+# 删除远端仓库（谨慎！）
+gh repo delete AllenS0104/mindkeep --yes
+
+# 删除某个 release
+gh release delete v0.1.0 --yes
+```

--- a/docs/AUTOLOAD-SETUP.md
+++ b/docs/AUTOLOAD-SETUP.md
@@ -1,0 +1,92 @@
+# Autoload Setup for AI Coding Agents
+
+This guide shows how to configure your AI coding assistant (GitHub Copilot CLI, Claude Code, or any other agent that reads a global instructions file) to **automatically recall mindkeep memory** at the start of every session — no per-project setup, no forgotten flags.
+
+The result: in **any** working directory (including brand-new empty folders), the agent runs `mindkeep show` on its first turn, prints a one-line summary of stored facts/ADRs, and treats them as authoritative project context.
+
+---
+
+## Why autoload?
+
+Without autoload, you (or the agent) must remember to run `mindkeep show --kind facts` at the start of every session. New projects, new branches, and new chat windows all become opportunities to forget. Autoload makes recall a property of the agent runtime instead of a habit.
+
+mindkeep's project ID is computed from `sha256(git-remote || abs-path)[:12]`, so it works for **any** directory — including folders without `.git`. There is no "is this a real project?" gate to fail.
+
+---
+
+## Setup
+
+### 1. Verify mindkeep is on your PATH
+
+```bash
+mindkeep --version    # should print 0.2.0 or newer
+```
+
+If not, install it: see [INSTALL.md](INSTALL.md).
+
+### 2. Add the autoload block to your agent instructions
+
+Append the snippet below to whichever global instructions file your agent reads:
+
+| Agent | File |
+|---|---|
+| GitHub Copilot CLI | `~/.copilot/AGENTS.md` |
+| Claude Code | `~/.claude/claude.md` |
+| Cursor (global) | `~/.cursor/rules/global.mdc` |
+| Other | whatever global / system-prompt file the agent loads |
+
+### Snippet
+
+```markdown
+## 🧠 mindkeep autoload
+
+At the **start of every session**, before responding to the user:
+
+1. Run: `mindkeep show --kind facts` and `mindkeep show --kind adrs`
+2. If either returns rows, print one line: `🧠 mindkeep recall: N facts, M ADRs loaded`
+3. Treat returned facts/ADRs as authoritative project context for the rest of the session.
+4. If `mindkeep` is not on PATH, silently skip (do not error).
+
+Skip autoload only when:
+- cwd is the user's home directory (`$HOME` / `%USERPROFILE%`)
+- cwd is a temp directory (`/tmp`, `%TEMP%`)
+
+Do **not** require `.git`, `pyproject.toml`, or any other project marker — mindkeep works in any directory.
+
+When the user asks you to "remember" something, use:
+- `mindkeep fact add "..."` for project facts
+- `mindkeep adr add "..."` for architectural decisions
+```
+
+### 3. Verify
+
+Open a new agent session in any directory. On its first turn, it should run `mindkeep show --kind facts` and print the recall line if anything is stored.
+
+---
+
+## Common pitfalls
+
+### ❌ Requiring a project marker
+
+A previous version of this guide gated autoload on the existence of `.git`, `pyproject.toml`, or `package.json`. **Don't do this.** Many real workflows start with an empty folder (`mkdir new-thing && cd new-thing`), and the gate causes silent skips exactly when you most want recall.
+
+### ❌ Wrong CLI syntax
+
+mindkeep uses **flag-style** subcommands:
+
+```bash
+mindkeep show --kind facts        # ✅ correct
+mindkeep show facts               # ❌ wrong (will print help)
+```
+
+### ❌ Forgetting to skip in `$HOME`
+
+Without the `$HOME` skip, opening a shell in your home directory dumps every fact you've ever stored on its parent project. Keep the skip narrow (just `$HOME` and `/tmp`-like dirs).
+
+---
+
+## Multi-agent consistency
+
+If you use both Copilot CLI and Claude Code, paste the same snippet into both files. The CLI behavior is identical because both invoke `mindkeep` as a subprocess.
+
+For team use, commit a `docs/agent-prompt-snippet.md` to your repo and tell teammates to paste it into their global agent instructions once. mindkeep itself stays per-user (the SQLite DB lives under `%APPDATA%` / `~/Library/Application Support` / `$XDG_DATA_HOME`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,8 @@ mindkeep/
     ├── USAGE.md ............. CLI reference + Python API + 8 cookbook recipes
     ├── UNINSTALL.md ......... backup, remove, PATH cleanup, compliance exit
     ├── FAQ.md ............... 22 questions across 5 categories
-    └── TROUBLESHOOTING.md ... 19 symptoms × (symptom / cause / diagnose / fix)
+    ├── TROUBLESHOOTING.md ... 19 symptoms × (symptom / cause / diagnose / fix)
+    └── AUTOLOAD-SETUP.md .... wire mindkeep into Copilot CLI / Claude Code so every session auto-recalls
 ```
 
 ---

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,68 @@
+# agent-memory v0.1.0
+
+First public release — a crash-safe, per-project long-term memory store for AI coding agents.
+
+## Highlights
+
+- 🛡️ **Crash-safe** — SQLite WAL mode with atomic writes; survives kill -9 / power loss.
+- 📦 **Per-project isolation** — Each project gets its own SQLite DB, keyed by a stable project id (cwd hash + optional override).
+- 🔗 **Cross-project preferences** — Shared store for user-level preferences that follow you across projects.
+- 🔒 **SecretsRedactor** — Built-in redaction filter strips API keys, tokens and common secret patterns before they hit disk.
+- 🪶 **Zero runtime dependencies** — Pure stdlib. Python 3.9+.
+- 🩺 **`doctor` subcommand** — One-shot health check for install, PATH, data dir, WAL support, filters and project detection.
+
+## Installation
+
+### 1. One-liner (share link)
+
+**Windows (PowerShell):**
+```powershell
+iwr https://raw.githubusercontent.com/AllenS0104/agent-memory/main/install.ps1 | iex
+```
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/AllenS0104/agent-memory/main/install.sh | bash
+```
+
+### 2. pipx (recommended for isolated CLI)
+
+```bash
+pipx install agent-memory
+```
+
+### 3. pip
+
+```bash
+pip install --user agent-memory
+```
+
+After install, run `agent-memory doctor` to verify.
+
+## SHA256 verification
+
+Artifacts are published alongside `SHA256SUMS`. To verify:
+
+```bash
+# macOS/Linux
+sha256sum -c SHA256SUMS
+
+# Windows (PowerShell)
+Get-FileHash agent_memory-0.1.0-py3-none-any.whl,agent_memory-0.1.0.tar.gz -Algorithm SHA256
+# compare against SHA256SUMS
+```
+
+Expected (also see `dist/SHA256SUMS`):
+
+```
+494ca7f9b497aa288c86d86c869c08c71ac5cb84d652acb747771e5b4513deb5  agent_memory-0.1.0-py3-none-any.whl
+43c1f95e86dd3c1cce66ba70d7104fd5099f91218e0ec8f76382a816fb888590  agent_memory-0.1.0.tar.gz
+```
+
+## Test status
+
+154 / 154 tests passing (pytest), covering storage, CLI, crash recovery, security, project-id, integration and scheduler.
+
+## License
+
+MIT

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -1,0 +1,34 @@
+# agent-memory v0.1.1
+
+Patch release — **line-ending hash parity fix**.
+
+## What's fixed
+
+v0.1.0 shipped `install.ps1` with CRLF line endings in the working tree (Windows `core.autocrlf=true` clone), but `raw.githubusercontent.com` serves the *stored* bytes. Because `SHA256SUMS` in v0.1.0 was computed against the CRLF working copy, users fetching `install.ps1` from the raw URL got a different hash and could not verify integrity.
+
+v0.1.1 guarantees a **single canonical byte stream** for install scripts across:
+
+- local git clone (any OS / any `autocrlf` setting)
+- `raw.githubusercontent.com/AllenS0104/agent-memory/main/install.{ps1,sh}`
+- `raw.githubusercontent.com/AllenS0104/agent-memory/v0.1.1/install.{ps1,sh}`
+- GitHub Release asset `install.{ps1,sh}`
+
+All four sources produce identical SHA-256 hashes matching the published `SHA256SUMS`.
+
+## How
+
+- Added `.gitattributes` pinning `install.ps1` and `install.sh` to `text eol=lf`.
+- Renormalized the working tree and re-staged both scripts as LF.
+- Recomputed `SHA256SUMS` on the LF bytes; `SHA256SUMS` itself is stored with LF line endings.
+
+## Verification
+
+Download any install script and compare:
+
+```powershell
+Invoke-WebRequest https://raw.githubusercontent.com/AllenS0104/agent-memory/v0.1.1/install.ps1 -OutFile $env:TEMP\install.ps1
+Get-FileHash -Algorithm SHA256 $env:TEMP\install.ps1
+# Compare to the install.ps1 line in SHA256SUMS (same release).
+```
+
+No API / behavioral changes — if v0.1.0 worked for you, nothing further is required.

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -1,0 +1,35 @@
+# v0.1.2
+
+## Fixes
+- Correct repository URLs in all documentation and install scripts (`v-songjun/agent-memory` → `AllenS0104/agent-memory`). v0.1.0 and v0.1.1 shipped with an obsolete owner name that 404'd for external users.
+- Align offline-wheel and SHA256SUMS references in README to this release.
+- Re-include the SHA256 verification block below so Release pages carry it directly.
+
+## Restates v0.1.1
+- `install.ps1` / `install.sh` are normalized to LF at rest so their SHA256 matches across `raw.githubusercontent.com`, Release assets, and local working tree.
+
+## 🔐 SHA256 checksums
+
+```
+1a3d24a15ba8a57a4a00eb1c822eddaa39a5c5a3b309cead1ba8ea64d4f1b00a  agent_memory-0.1.2-py3-none-any.whl
+983180bbdb8caf68f13e1d2487ee7cf727f3eec8cbe1731f8ec0caab296dd7a4  agent_memory-0.1.2.tar.gz
+f02d2fc2343c6f31373a15d6047375422ea63d7c8977a7b3c2a495395716bcfc  install.ps1
+7b32a5642a9a56de8030d64066b0b385ca51897d48c6c63ba1a90059769a2ba6  install.sh
+```
+
+### Verify before running
+
+**Windows (PowerShell)**
+```powershell
+iwr https://github.com/AllenS0104/agent-memory/releases/latest/download/install.ps1 -OutFile install.ps1
+iwr https://github.com/AllenS0104/agent-memory/releases/latest/download/SHA256SUMS -OutFile SHA256SUMS
+(Get-FileHash -Algorithm SHA256 install.ps1).Hash.ToLower()
+# Compare with the SHA256SUMS line for install.ps1
+```
+
+**macOS / Linux**
+```bash
+curl -fsSL -o install.sh https://github.com/AllenS0104/agent-memory/releases/latest/download/install.sh
+curl -fsSL -o SHA256SUMS https://github.com/AllenS0104/agent-memory/releases/latest/download/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+```

--- a/docs/releases/v0.1.3.md
+++ b/docs/releases/v0.1.3.md
@@ -1,0 +1,33 @@
+# v0.1.3
+
+## Changes
+- chore: fix `pyproject.toml` authors handle (`v-songjun` → `AllenS0104`) so `pip show agent-memory` displays the correct GitHub handle.
+- docs: update `install.ps1` / `install.sh` help docstring examples to reference the current wheel version (`agent_memory-0.1.0-*.whl` → `agent_memory-0.1.3-*.whl`). The default `-Source` already pointed to the git repo; only the stale example text is updated.
+
+No functional or behavioral changes. SHA256 values are updated because the wheel and sdist were rebuilt.
+
+## 🔐 SHA256 checksums
+
+```
+548e9d47eaa240fa6de3e7f645f2628f26b89f6ce73f11a210a01c2cc74c9006  agent_memory-0.1.3-py3-none-any.whl
+fd8c3e2aee81e4058ec650f67c2af2f4317b7cef987b8312aa401290241699cd  agent_memory-0.1.3.tar.gz
+cb08650c860d771d77c0596bb9ba61ef745e7defbfc2f0716636b7e16c516153  install.ps1
+31bb25824bd66b3fcfdade7c74f372b89d0db78f2490516409c25273c3e13558  install.sh
+```
+
+### Verify before running
+
+**Windows (PowerShell)**
+```powershell
+iwr https://github.com/AllenS0104/agent-memory/releases/latest/download/install.ps1 -OutFile install.ps1
+iwr https://github.com/AllenS0104/agent-memory/releases/latest/download/SHA256SUMS -OutFile SHA256SUMS
+(Get-FileHash -Algorithm SHA256 install.ps1).Hash.ToLower()
+# Compare with the SHA256SUMS line for install.ps1
+```
+
+**macOS / Linux**
+```bash
+curl -fsSL -o install.sh https://github.com/AllenS0104/agent-memory/releases/latest/download/install.sh
+curl -fsSL -o SHA256SUMS https://github.com/AllenS0104/agent-memory/releases/latest/download/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+```

--- a/docs/releases/v0.1.4.md
+++ b/docs/releases/v0.1.4.md
@@ -1,0 +1,39 @@
+# agent-memory v0.1.4
+
+## Changes
+- fix: `agent-memory --version` now reads the installed package version dynamically via `importlib.metadata` (was hardcoded `"0.1.0"` and incorrectly reported `0.1.0` for every release since v0.1.0).
+- chore: sanitize hardcoded local Windows paths (`C:\Users\v-songjun\agent-memory`) in `NEXT-STEPS.md` and `PUBLISH.md` to portable placeholders (`$env:REPO_ROOT` / `<repo-root>`) so docs are reproducible for any contributor.
+
+No behavioral changes to the storage layer. Wheel/sdist rebuilt with the new version metadata.
+
+## 🔐 SHA256 checksums
+
+```
+7a4ebc2b7710ed09dfcee9f94a20d5088a07468f6b609cf6f353c0b01913c662  agent_memory-0.1.4-py3-none-any.whl
+2ff679f7771431c0d8e997839cd1e9b7349a9e49d03a69510eb6d24e4ea31289  agent_memory-0.1.4.tar.gz
+2589096233aad8f3e67c04b94047619ebc783383a639997cdcaed1593800e411  install.ps1
+9c2b04f856405417e6c70408fb2aaec776a1ed73d37abd83c280d027415a7dc8  install.sh
+```
+
+### Verify before running
+
+**Windows (PowerShell)**
+```powershell
+iwr https://github.com/AllenS0104/agent-memory/releases/latest/download/install.ps1 -OutFile install.ps1
+iwr https://github.com/AllenS0104/agent-memory/releases/latest/download/SHA256SUMS -OutFile SHA256SUMS
+(Get-FileHash -Algorithm SHA256 install.ps1).Hash.ToLower()
+# Compare with the SHA256SUMS line for install.ps1
+```
+
+**macOS / Linux**
+```bash
+curl -fsSL -o install.sh https://github.com/AllenS0104/agent-memory/releases/latest/download/install.sh
+curl -fsSL -o SHA256SUMS https://github.com/AllenS0104/agent-memory/releases/latest/download/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+### Smoke test
+```bash
+agent-memory --version
+# → agent-memory 0.1.4
+```

--- a/docs/releases/v0.1.5.md
+++ b/docs/releases/v0.1.5.md
@@ -1,0 +1,39 @@
+# agent-memory v0.1.5
+
+## Changes
+- feat: friendly aliases `remember_fact` / `remember_adr` / `recall_facts` / `recall_adrs` on `MemoryStore` — identical signatures and return types to the existing `add_fact` / `add_adr` / `list_facts` / `list_adrs` methods. Pure aliases, no behavior change. Lets agent-facing code use the more natural `remember_*` / `recall_*` voice without giving up the canonical names.
+- test: alias call-equivalence and identity assertions (`tests/test_aliases.py`). Suite now at **159 passing** (was 154).
+
+No changes to the storage layer, on-disk format, or CLI surface. Wheel/sdist rebuilt with the new version metadata.
+
+## 🔐 SHA256 checksums
+
+```
+1068e52907561bd3dd6fab98cfaac2814e86b25988506ea0ce0841da2387e994  agent_memory-0.1.5-py3-none-any.whl
+6dcb2e964987d279f38effa1529b0bb8ca28d12092a5487c66e6443ef2d2aa3f  agent_memory-0.1.5.tar.gz
+65bf0549239281ca8e985e74fbfe5cf6da843db294b47e319889d0c550f79782  install.ps1
+88f4d9490805249f9fd48da1e432f78ce5e64db8a1f6fc7ebf23eef0dda5a9c4  install.sh
+```
+
+### Verify before running
+
+**Windows (PowerShell)**
+```powershell
+iwr https://github.com/AllenS0104/agent-memory/releases/latest/download/install.ps1 -OutFile install.ps1
+iwr https://github.com/AllenS0104/agent-memory/releases/latest/download/SHA256SUMS -OutFile SHA256SUMS
+(Get-FileHash -Algorithm SHA256 install.ps1).Hash.ToLower()
+# Compare with the SHA256SUMS line for install.ps1
+```
+
+**macOS / Linux**
+```bash
+curl -fsSL -o install.sh https://github.com/AllenS0104/agent-memory/releases/latest/download/install.sh
+curl -fsSL -o SHA256SUMS https://github.com/AllenS0104/agent-memory/releases/latest/download/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+### Smoke test
+```bash
+agent-memory --version
+# → agent-memory 0.1.5
+```


### PR DESCRIPTION
## Summary

Three logical commits against `main`:

1. **`fix(packaging)`** — corrects a real packaging bug: `MANIFEST.in` still pointed at `src/agent_memory` (the legacy directory name) post-rename. The current `main` builds an sdist that **silently drops `py.typed`** and any non-`.py` data files under `src/mindkeep/`. Anyone installing mindkeep from sdist loses type information.

2. **`docs: restore v0.1.x release history`** — re-introduces the historical release notes (`docs/releases/v0.1.0.md` … `v0.1.5.md`) that documented the security hardening work (SQL whitelist, secrets redactor), the install-script CRLF fix (`v0.1.1`), and the repo-URL correction (`v0.1.2`). Merges those entries into `CHANGELOG.md` so v0.2.0's provenance is visible in-tree. The existing v0.2.0 entry is preserved verbatim, with prior history prepended above it.

3. **`docs: add AUTOLOAD-SETUP guide + NEXT-STEPS + PUBLISH`**:
   - **`docs/AUTOLOAD-SETUP.md`** — how to wire `mindkeep` into Copilot CLI / Claude Code global instruction files so every new session auto-recalls facts/ADRs. Explicitly warns against two common mistakes I hit while setting this up myself:
     - Gating on `.git` / `pyproject.toml` (breaks the very common "empty folder, just started" workflow — autoload silently no-ops exactly when you most want recall).
     - Wrong subcommand syntax (`mindkeep show facts` vs the correct `mindkeep show --kind facts`).
   - **`NEXT-STEPS.md` / `PUBLISH.md`** — maintainer-facing roadmap & publish-flow docs.
   - **`docs/README.md`** — link `AUTOLOAD-SETUP` from the docs index.

## Test plan

- The packaging fix is verifiable with `python -m build --sdist && tar -tzf dist/mindkeep-0.2.0.tar.gz | grep py.typed` (will appear with this PR; would be missing on `main`).
- All other changes are docs-only (no test impact).

## Notes

The first commit is the only one that should be considered for cherry-pick into a `0.2.1` patch release; the other two are pure docs and can ride along whenever convenient.