### PR TITLE
fix(packaging): correct MANIFEST.in path to src/mindkeep

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include README.md
 include ARCHITECTURE.md
 include LICENSE
 include pyproject.toml
-recursive-include src/agent_memory *.py py.typed
+recursive-include src/mindkeep *.py py.typed
 recursive-exclude tests *
 global-exclude __pycache__
 global-exclude *.py[cod]


### PR DESCRIPTION
Single-line fix. `MANIFEST.in` still pointed at the legacy `src/agent_memory` directory, so:

- The `recursive-include` matched zero files post-rename.
- The sdist on GitHub Releases is missing `py.typed`.
- Anyone installing mindkeep from sdist (or from PyPI when published) loses type information.

Verifiable after merge with: `python -m build --sdist && tar -tzf dist/mindkeep-*.tar.gz | grep py.typed`.

Pure packaging fix; no code, docs, or test changes.