### PR TITLE
feat(storage): schema v3 (P0-1) - salience columns + FTS5

### DIFF
--- a/docs/DESIGN-v0.3.0.md
+++ b/docs/DESIGN-v0.3.0.md
@@ -1,0 +1,403 @@
+# mindkeep v0.3.0 Design Document
+
+> Status: **Approved with conditions** · Source: PMO meeting 2026-04-29
+> Release gate: Eval suite (Issue #10) must pass before tagging v0.3.0.
+
+This document is the source-of-truth design record for mindkeep v0.3.0. It
+captures the consensus of a four-perspective review (Architect, Product,
+Cost-Economist, Skeptic) and the rationale for what ships, what is deferred,
+and the constraints each contributor placed on the design.
+
+---
+
+## 1. Goals
+
+v0.3.0 is the release where mindkeep stops being "a small SQLite-backed note
+store with a CLI" and becomes "a token-aware memory layer that an AI agent can
+plug into." The four headline goals — in priority order — are:
+
+1. **Reduce per-session token cost by ~3× on the Typical workload**
+   (50 facts + 10 ADRs). v0.2.0 dumps everything; v0.3.0 must show only what
+   the session asks for, plus pinned items.
+2. **Provide intent-triggered retrieval.** Move from `autoload everything` to
+   `recall on demand`. The agent decides when to ask; mindkeep decides what to
+   return.
+3. **Multi-agent integration.** Ship first-class on-ramps for Claude (skills),
+   GitHub Copilot CLI (`AGENTS.md`), Cursor (`.cursor/rules/*.mdc`), and a
+   generic adapter for other agents.
+4. **Make every "saves tokens" claim quantifiable.** Every cost claim in
+   marketing or docs must be reproducible via `mindkeep stats` and the eval
+   suite (Issue #10). No hand-wavy numbers.
+
+### Non-goals (deferred to v0.4 or later)
+
+- **Automatic salience scoring formula.** Only manual `--pin` lands in v0.3.0.
+  We do not yet have enough usage data to design a scoring function that won't
+  immediately be wrong.
+- **`gc --older-than --unread`.** No real users means no rotting data to
+  validate the heuristics against. Shipping a destructive command without a
+  test population is how you delete people's notes.
+- **LLM-side summarization, vector embeddings, MCP server.** All three are
+  plausible v0.4+ work but are out of scope here. Each one breaks the
+  zero-runtime-dependency posture in a different way and needs its own design
+  doc.
+
+---
+
+## 2. Workload assumptions (Cost-Economist)
+
+All cost claims are anchored to a single reference workload, defined here so
+the eval suite can reproduce it.
+
+### Typical workload
+
+- **Store:** 50 facts (avg ~80 tokens each) + 10 ADRs (avg ~220 tokens each).
+- **Session shape:** 1 implicit context load at session start, followed by
+  ~3 explicit `recall` calls during the session.
+- **Estimator:** zero-dep heuristic, `tokens ≈ ceil(chars / 4)` for ASCII,
+  `ceil(chars / 2)` for CJK-heavy text. Calibrated against tiktoken on a
+  fixture corpus to within ±15% — close enough for budgeting decisions.
+
+### Token math
+
+| Component                          |   Tokens | Notes                                              |
+| ---------------------------------- | -------: | -------------------------------------------------- |
+| v0.2.0 baseline (autoload all)     |   ~3,400 | 50×80 (facts) + 10×220 (ADRs) + framing overhead   |
+| v0.3.0 target (Typical session)    |   ~1,130 | ~50 (registry) + 3×175 (recalls) + ~555 (pinned)   |
+| Skill registry tax (always paid)   |     ~50 | Floor cost: agent must learn `recall` exists       |
+| Per-`recall` overhead              |    ~175 | top-5 hits w/ snippets, BM25-ranked                |
+| Pinned items budget                |    ~555 | Cap at 6 pinned items × ~92 tokens (median fact)   |
+
+**3× claim derivation:** `3,400 / 1,130 ≈ 3.01`. The claim is "approximately
+3×" specifically so it survives normal variance. The eval suite must report
+the actual ratio per run; if it drops below 2.5× on the Typical workload, the
+release is blocked.
+
+### Heavy workload (sanity check)
+
+500 facts + 50 ADRs. v0.2.0 baseline is too large for many context windows
+(>30k tokens); v0.3.0 stays bounded by `--budget` regardless of store size.
+This is the primary qualitative win — cost stops scaling with store size.
+
+---
+
+## 3. Schema changes (v3) — Architect
+
+### 3.1 New columns on `facts` and `adrs`
+
+```sql
+-- Applied to BOTH facts and adrs unless noted.
+ALTER TABLE facts ADD COLUMN last_accessed_at TIMESTAMP NULL;
+ALTER TABLE facts ADD COLUMN access_count    INTEGER  NOT NULL DEFAULT 0;
+ALTER TABLE facts ADD COLUMN pin             INTEGER  NOT NULL DEFAULT 0; -- 0 or 1
+ALTER TABLE facts ADD COLUMN archived_at     TIMESTAMP NULL;
+ALTER TABLE facts ADD COLUMN token_estimate  INTEGER  NULL;
+
+ALTER TABLE adrs  ADD COLUMN last_accessed_at TIMESTAMP NULL;
+ALTER TABLE adrs  ADD COLUMN access_count    INTEGER  NOT NULL DEFAULT 0;
+ALTER TABLE adrs  ADD COLUMN pin             INTEGER  NOT NULL DEFAULT 0;
+ALTER TABLE adrs  ADD COLUMN archived_at     TIMESTAMP NULL;
+ALTER TABLE adrs  ADD COLUMN token_estimate  INTEGER  NULL;
+```
+
+Field semantics:
+
+- `last_accessed_at` — set on every `recall` hit and every `show <id>`. NULL
+  means "never accessed under v3 tracking" (legacy or freshly inserted).
+- `access_count` — monotonically increasing. Never decremented. Used for
+  read-heavy detection in stats; not used for ordering in v0.3.0.
+- `pin` — 0/1 boolean. Pinned items are always candidates for the
+  pinned-items budget. There is no priority among pinned items in v0.3.0;
+  ordering is by recency of pinning.
+- `archived_at` — soft-delete sentinel. Archived rows are excluded from
+  `recall` and `show` by default but remain queryable with `--include-archived`.
+- `token_estimate` — computed at write time using the heuristic from §2. Cached
+  to avoid recomputation in stats. `mindkeep doctor --recompute-tokens` exists
+  for callers who change the estimator.
+
+### 3.2 FTS5 virtual tables
+
+```sql
+CREATE VIRTUAL TABLE facts_fts USING fts5(
+    content, tags,
+    content='facts',
+    content_rowid='rowid',
+    tokenize='unicode61 remove_diacritics 2'
+);
+
+CREATE VIRTUAL TABLE adrs_fts USING fts5(
+    title, decision, rationale,
+    content='adrs',
+    content_rowid='rowid',
+    tokenize='unicode61 remove_diacritics 2'
+);
+```
+
+`unicode61` is required for CJK because the default `simple` tokenizer
+splits on whitespace only and would treat a Chinese paragraph as one token.
+
+### 3.3 FTS sync triggers
+
+```sql
+CREATE TRIGGER facts_ai AFTER INSERT ON facts BEGIN
+  INSERT INTO facts_fts(rowid, content, tags)
+  VALUES (new.rowid, new.content, new.tags);
+END;
+
+CREATE TRIGGER facts_ad AFTER DELETE ON facts BEGIN
+  INSERT INTO facts_fts(facts_fts, rowid, content, tags)
+  VALUES ('delete', old.rowid, old.content, old.tags);
+END;
+
+CREATE TRIGGER facts_au AFTER UPDATE ON facts BEGIN
+  INSERT INTO facts_fts(facts_fts, rowid, content, tags)
+  VALUES ('delete', old.rowid, old.content, old.tags);
+  INSERT INTO facts_fts(rowid, content, tags)
+  VALUES (new.rowid, new.content, new.tags);
+END;
+```
+
+Equivalent triplet for `adrs_fts` over `(title, decision, rationale)`. The
+`content=` external-content pattern was chosen over storing-in-FTS to keep the
+authoritative copy of each row in the base table — backups stay simple.
+
+### 3.4 Migration policy (Skeptic-mandated)
+
+The Skeptic's central concern: "you do not know what timestamps mean for rows
+that existed before you started tracking timestamps. Do not lie about them."
+
+Rules:
+
+1. All new columns must be NULLable or have a default of 0. No backfilling
+   `last_accessed_at = NOW()` — that would be a lie. Legacy rows stay NULL.
+2. A new bookkeeping row in `meta`:
+   ```sql
+   INSERT INTO meta(key, value) VALUES
+     ('access_tracking_started_at', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+   ```
+   Any future analysis that depends on access timestamps must read this row
+   and carve out a "tracking blind spot" before this date.
+3. Future destructive commands that touch staleness (e.g. `gc --unread`) MUST
+   require an explicit `--include-unknown-access` flag to act on rows where
+   `last_accessed_at IS NULL`. Default behavior: skip with a warning.
+4. Schema version bumped to `3` in `meta.schema_version`. `mindkeep doctor`
+   refuses to operate on schemas it does not understand and prints the upgrade
+   command.
+5. Migration is one-way. There is no v3→v2 downgrade. Users who need the old
+   shape are told to restore from backup. (mindkeep is a notes store; it is
+   the user's responsibility to back up the SQLite file, and we document it.)
+
+---
+
+## 4. CLI surface diff
+
+### 4.1 Existing commands — extended
+
+| Command           | Status   | Change                                                                 |
+| ----------------- | -------- | ---------------------------------------------------------------------- |
+| `mindkeep show`   | extended | New flags: `--top N`, `--budget TOKENS`, `--pinned`                    |
+| `mindkeep doctor` | extended | Now reports token usage, schema version, FTS5 health, orphaned indexes |
+
+`show --top N` returns the N most relevant items for the implicit session
+context. `--budget TOKENS` is a hard cap; selection greedily picks
+highest-ranked items that fit. `--pinned` restricts output to pinned items
+only and is intended for `integrate`-generated bootstrap snippets.
+
+### 4.2 New commands
+
+| Command                                      | Purpose                                  |
+| -------------------------------------------- | ---------------------------------------- |
+| `mindkeep recall <query> [--top N] [--budget T]` | FTS5 + BM25 retrieval                |
+| `mindkeep stats [--json]`                    | Introspection: counts, tokens, hit rates |
+| `mindkeep pin <id>` / `mindkeep unpin <id>`  | Minimal manual salience                  |
+| `mindkeep integrate <target>`                | Replaces former "skill emit"             |
+
+`recall` ranks via BM25 on the FTS table, then re-orders to push pinned items
+into the result set if they match the query at all (pinned-and-matched > raw
+BM25 > unpinned BM25 within budget). It updates `last_accessed_at` and
+increments `access_count` for every returned row, in a single transaction.
+
+`stats --json` emits a stable schema (documented in `docs/USAGE.md` once
+implemented) so the eval suite can consume it directly.
+
+`integrate <target>` accepts: `claude`, `copilot`, `cursor`, `generic`. It
+writes the appropriate file(s) for that target into the current directory and
+prints the path(s). Re-running is idempotent: existing files are diffed and
+the user is prompted before overwrite.
+
+---
+
+## 5. Session-level token budget
+
+mindkeep cannot enforce token usage inside the agent — it can only enforce
+what *it* returns. The mechanism:
+
+- **Environment variable:** `MINDKEEP_SESSION_BUDGET=<int>`. If unset, no
+  session-level cap is enforced (per-call `--budget` still applies).
+- **State file:** a small JSON file with `{ "session_id": "...", "spent": N,
+  "started_at": "..." }`. Location:
+  - Linux/macOS: `$XDG_RUNTIME_DIR/mindkeep/session.json`, falling back to
+    `$TMPDIR/mindkeep-$UID/session.json`.
+  - Windows: `%LOCALAPPDATA%\Temp\mindkeep\session.json`.
+- **Reset semantics:** a session is identified by `MINDKEEP_SESSION_ID`. If
+  unset or changed, the state file is reset on next call. `mindkeep stats
+  --reset-session` forces a reset.
+- **Enforcement:** when `recall` or `show` would exceed the remaining
+  budget, results are truncated to fit and a one-line warning is printed to
+  stderr (never stdout — stdout is for the agent). Exit code stays 0; running
+  out of budget is not an error, it's a constraint.
+
+Rationale for stderr-only warnings: agents tend to echo whatever they see on
+stdout back to the user. Budget exhaustion is operational metadata, not part
+of the recall payload.
+
+---
+
+## 6. Trigger design (multi-agent integration)
+
+The four supported targets have genuinely different loading models, and
+pretending they're the same produces a worse experience for all four. The
+guiding principle: **describe intent, not phrases.** Listing trigger phrases
+("when the user says 'remember that'…") is brittle and dates badly. Describing
+intent ("when the user references a prior decision the agent does not have in
+context") survives model changes.
+
+### 6.1 Per-target loading models
+
+- **Claude (skills):** loaded into a session via the skills directory.
+  Registry tax is paid once per session; mindkeep ships a `SKILL.md` that
+  describes when to invoke `recall`.
+- **GitHub Copilot CLI:** reads `AGENTS.md` from the project root. The
+  integration writes a section that points the agent at `mindkeep recall` and
+  `mindkeep show --top`.
+- **Cursor:** loads `.cursor/rules/*.mdc` files. mindkeep writes a
+  `mindkeep.mdc` rule that describes when to call `recall`.
+- **Generic:** a plain `MINDKEEP.md` describing the same intent in
+  agent-agnostic language, suitable for tools we do not yet support.
+
+### 6.2 Sample artifacts
+
+`SKILL.md` (Claude) — stub:
+
+```markdown
+---
+name: mindkeep
+description: Recall prior project facts and decisions before answering.
+---
+
+Use `mindkeep recall <query>` when the user references a prior decision,
+naming convention, or fact you do not already have in context. Prefer
+`recall` over re-asking the user. Pinned items will appear first.
+```
+
+`AGENTS.md` (Copilot CLI) — snippet:
+
+```markdown
+## Project memory
+
+This project uses [mindkeep](https://github.com/AllenS0104/mindkeep) as a
+local memory store.
+
+- Before answering questions about prior decisions, run
+  `mindkeep recall "<topic>" --top 5`.
+- To see currently pinned context, run `mindkeep show --pinned`.
+- Do not modify the store on the user's behalf without explicit confirmation.
+```
+
+`.cursor/rules/mindkeep.mdc` — snippet:
+
+```markdown
+---
+description: Use mindkeep to recall prior project facts and decisions.
+globs: ["**/*"]
+alwaysApply: true
+---
+
+When the user refers to a prior decision, convention, or fact that is not in
+the current context window, call `mindkeep recall "<query>" --top 5` and
+incorporate the results before answering. Pinned items take priority.
+```
+
+All three intentionally avoid hard-coded phrase lists. They tell the agent
+*when* (intent) and *what* (the command), not *which words trigger it*.
+
+---
+
+## 7. Dependency graph
+
+Issue numbers TBD when issues are filed; structure is fixed.
+
+```
+P0-1 schema (FTS5 + new columns + migration)
+     ├─→ P0-2 session budget (env + state file)
+     ├─→ P0-3 show --top / --budget
+     ├─→ P0-4 recall command
+     │        └─→ P1-5 integrate <target>
+     ├─→ P1-6 stats --json
+     │        └─→ P1-9 doctor (token usage, FTS health)
+     ├─→ P1-7 write guard (token_estimate at insert)
+     └─→ P1-8 pin / unpin
+
+   All of the above ─→ P2-10 eval suite gate
+```
+
+P0 must land before any P1. P2-10 (eval gate) is the last thing standing
+between `main` and a `v0.3.0` tag.
+
+---
+
+## 8. Cut from scope (with rationale)
+
+Each cut has a named owner-perspective, so future contributors know who to
+ask before resurrecting it.
+
+- **`mindkeep summary` standalone command** — *Product.* Already covered by
+  `recall "" --top 5`. A second command surface for the same operation
+  doubles the docs burden without adding capability.
+- **Token-count footer always-on** — *Cost-Economist.* Always-on numbers
+  invite the agent to comment on them, which costs more tokens than the
+  numbers were worth. Ships as opt-in `--show-cost` only.
+- **`gc --older-than --unread`** — *Skeptic.* No real users → no rotting
+  data → no way to validate the policy → high risk of deleting things people
+  cared about. Re-evaluate in v0.4 once we have telemetry from real installs.
+- **Salience scoring formula** — *Architect + Skeptic.* Designing a scoring
+  function from no data is fiction. Ship `--pin` only; collect access data
+  via the v3 schema; revisit in v0.3.1 with real frequencies.
+- **"Skill emit" as a universal feature** — *Architect.* The four targets
+  have different file formats and different loading models; pretending
+  otherwise produces a worst-of-all-worlds output. Replaced by `integrate
+  <target>` with target-specific generators.
+
+---
+
+## 9. Open questions
+
+These are decisions made provisionally; they may be revisited in v0.3.1 with
+real-world data, but they should not block v0.3.0.
+
+- **Token estimator: tiktoken vs heuristic?**
+  Decision: heuristic (`chars/4` for ASCII, `chars/2` for CJK). Adding
+  tiktoken would add a non-trivial native dependency and break the
+  zero-runtime-dep posture, which is a core value. ±15% accuracy is more
+  than enough for budgeting; we are not billing anyone.
+- **Session-budget storage path on Windows.**
+  Decision: `%LOCALAPPDATA%\Temp\mindkeep\session.json`. There is no exact
+  XDG analog on Windows; `%LOCALAPPDATA%\Temp` is the closest match for
+  "ephemeral, per-user." Documented alongside the Linux/macOS path.
+- **Release timing.**
+  Gated on two conditions: (a) eval suite green on the Typical workload
+  showing ≥2.5× reduction; (b) at least one non-maintainer user has
+  successfully run `mindkeep integrate` against their agent of choice and
+  reported back. Time is not a gate.
+
+---
+
+## 10. References
+
+- PR #5 — PyPI publish documentation. Completed prerequisite; v0.3.0
+  releases will use that pipeline unchanged.
+- Issues #1–#10 — implementation tracking, to be filed against this design.
+  Numbering in the dependency graph (§7) is provisional and will be updated
+  once GitHub assigns real numbers.
+- `docs/USAGE.md` — will be updated alongside the feature PRs, not in this
+  doc PR. This file is the design; USAGE is the user-facing reference.

--- a/src/mindkeep/cli.py
+++ b/src/mindkeep/cli.py
@@ -29,7 +29,7 @@ from typing import Any, Sequence
 from .memory_api import MemoryStore
 from .models import ProjectId
 from .project_id import resolve_project_id
-from .storage import Storage, default_data_dir
+from .storage import SCHEMA_VERSION, Storage, default_data_dir
 
 __all__ = ["main"]
 
@@ -399,7 +399,7 @@ def _cmd_export(data_dir: Path, args: argparse.Namespace) -> int:
     ps = _open_pref_storage(data_dir)
     try:
         payload = {
-            "meta": {"project_hash": ph, "schema_version": 1,
+            "meta": {"project_hash": ph, "schema_version": SCHEMA_VERSION,
                      "meta_row": _meta_row(s)},
             "facts": s.query("facts"),
             "adrs": s.query("adrs"),

--- a/src/mindkeep/storage.py
+++ b/src/mindkeep/storage.py
@@ -13,6 +13,7 @@ Only stdlib is used. Python >= 3.11.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 import sys
@@ -21,7 +22,9 @@ import time
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 3
+
+_log = logging.getLogger(__name__)
 
 # Whitelisted tables — we never accept table names from callers unchecked.
 _ALLOWED_TABLES: frozenset[str] = frozenset(
@@ -34,26 +37,32 @@ _ALLOWED_TABLES: frozenset[str] = frozenset(
 _DDL: tuple[str, ...] = (
     """
     CREATE TABLE IF NOT EXISTS meta (
-        id                INTEGER PRIMARY KEY CHECK (id = 1),
-        schema_version    INTEGER NOT NULL,
-        project_id        TEXT    NOT NULL DEFAULT '',
-        display_name      TEXT    NOT NULL DEFAULT '',
-        id_source         TEXT    NOT NULL DEFAULT '',
-        origin_value      TEXT    NOT NULL DEFAULT '',
-        created_at        TEXT    NOT NULL,
-        updated_at        TEXT    NOT NULL
+        id                            INTEGER PRIMARY KEY CHECK (id = 1),
+        schema_version                INTEGER NOT NULL,
+        project_id                    TEXT    NOT NULL DEFAULT '',
+        display_name                  TEXT    NOT NULL DEFAULT '',
+        id_source                     TEXT    NOT NULL DEFAULT '',
+        origin_value                  TEXT    NOT NULL DEFAULT '',
+        access_tracking_started_at    TEXT,
+        created_at                    TEXT    NOT NULL,
+        updated_at                    TEXT    NOT NULL
     )
     """,
     """
     CREATE TABLE IF NOT EXISTS facts (
-        id           INTEGER PRIMARY KEY AUTOINCREMENT,
-        key          TEXT    NOT NULL,
-        value        TEXT    NOT NULL,
-        tags         TEXT    NOT NULL DEFAULT '',
-        source       TEXT    NOT NULL DEFAULT 'agent',
-        confidence   REAL    NOT NULL DEFAULT 1.0,
-        created_at   TEXT    NOT NULL,
-        updated_at   TEXT    NOT NULL,
+        id                INTEGER PRIMARY KEY AUTOINCREMENT,
+        key               TEXT    NOT NULL,
+        value             TEXT    NOT NULL,
+        tags              TEXT    NOT NULL DEFAULT '',
+        source            TEXT    NOT NULL DEFAULT 'agent',
+        confidence        REAL    NOT NULL DEFAULT 1.0,
+        last_accessed_at  TEXT,
+        access_count      INTEGER NOT NULL DEFAULT 0,
+        pin               INTEGER NOT NULL DEFAULT 0,
+        archived_at       TEXT,
+        token_estimate    INTEGER,
+        created_at        TEXT    NOT NULL,
+        updated_at        TEXT    NOT NULL,
         UNIQUE(key)
     )
     """,
@@ -61,18 +70,23 @@ _DDL: tuple[str, ...] = (
     "CREATE INDEX IF NOT EXISTS idx_facts_updated ON facts(updated_at DESC)",
     """
     CREATE TABLE IF NOT EXISTS adrs (
-        id           INTEGER PRIMARY KEY AUTOINCREMENT,
-        number       INTEGER NOT NULL,
-        title        TEXT    NOT NULL,
-        status       TEXT    NOT NULL,
-        context      TEXT    NOT NULL,
-        decision     TEXT    NOT NULL,
-        alternatives TEXT    NOT NULL DEFAULT '',
-        consequences TEXT    NOT NULL DEFAULT '',
-        supersedes   INTEGER,
-        tags         TEXT    NOT NULL DEFAULT '',
-        created_at   TEXT    NOT NULL,
-        updated_at   TEXT    NOT NULL,
+        id                INTEGER PRIMARY KEY AUTOINCREMENT,
+        number            INTEGER NOT NULL,
+        title             TEXT    NOT NULL,
+        status            TEXT    NOT NULL,
+        context           TEXT    NOT NULL,
+        decision          TEXT    NOT NULL,
+        alternatives      TEXT    NOT NULL DEFAULT '',
+        consequences      TEXT    NOT NULL DEFAULT '',
+        supersedes        INTEGER,
+        tags              TEXT    NOT NULL DEFAULT '',
+        last_accessed_at  TEXT,
+        access_count      INTEGER NOT NULL DEFAULT 0,
+        pin               INTEGER NOT NULL DEFAULT 0,
+        archived_at       TEXT,
+        token_estimate    INTEGER,
+        created_at        TEXT    NOT NULL,
+        updated_at        TEXT    NOT NULL,
         UNIQUE(number),
         FOREIGN KEY (supersedes) REFERENCES adrs(id)
     )
@@ -105,6 +119,205 @@ _DDL: tuple[str, ...] = (
     """,
     "CREATE INDEX IF NOT EXISTS idx_prefs_updated ON preferences(updated_at DESC)",
 )
+
+# FTS5 virtual tables + triggers (created on fresh stores and during
+# v1/v2→v3 migration when the SQLite build supports FTS5).
+#
+# Note: FTS column names mirror the source columns (facts.value, adrs.context)
+# rather than the names from the v0.3.0 task spec ("content", "rationale"),
+# so that external-content lookups by FTS5 work without column-name mapping.
+# This is a deviation from the spec; behaviour for MATCH queries is identical.
+_FTS_DDL: tuple[str, ...] = (
+    """
+    CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts USING fts5(
+        value,
+        tags,
+        content=facts,
+        content_rowid=rowid,
+        tokenize='unicode61 remove_diacritics 1'
+    )
+    """,
+    """
+    CREATE VIRTUAL TABLE IF NOT EXISTS adrs_fts USING fts5(
+        title,
+        decision,
+        context,
+        content=adrs,
+        content_rowid=rowid,
+        tokenize='unicode61 remove_diacritics 1'
+    )
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS facts_ai AFTER INSERT ON facts BEGIN
+        INSERT INTO facts_fts(rowid, value, tags)
+            VALUES (new.rowid, new.value, new.tags);
+    END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS facts_ad AFTER DELETE ON facts BEGIN
+        INSERT INTO facts_fts(facts_fts, rowid, value, tags)
+            VALUES ('delete', old.rowid, old.value, old.tags);
+    END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS facts_au AFTER UPDATE ON facts BEGIN
+        INSERT INTO facts_fts(facts_fts, rowid, value, tags)
+            VALUES ('delete', old.rowid, old.value, old.tags);
+        INSERT INTO facts_fts(rowid, value, tags)
+            VALUES (new.rowid, new.value, new.tags);
+    END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS adrs_ai AFTER INSERT ON adrs BEGIN
+        INSERT INTO adrs_fts(rowid, title, decision, context)
+            VALUES (new.rowid, new.title, new.decision, new.context);
+    END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS adrs_ad AFTER DELETE ON adrs BEGIN
+        INSERT INTO adrs_fts(adrs_fts, rowid, title, decision, context)
+            VALUES ('delete', old.rowid, old.title, old.decision, old.context);
+    END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS adrs_au AFTER UPDATE ON adrs BEGIN
+        INSERT INTO adrs_fts(adrs_fts, rowid, title, decision, context)
+            VALUES ('delete', old.rowid, old.title, old.decision, old.context);
+        INSERT INTO adrs_fts(rowid, title, decision, context)
+            VALUES (new.rowid, new.title, new.decision, new.context);
+    END
+    """,
+)
+
+
+def fts5_available() -> bool:
+    """Return True iff the running SQLite build can create FTS5 tables.
+
+    Implemented as a probe (CREATE VIRTUAL TABLE … USING fts5) on a throwaway
+    in-memory connection. Used both by the migration (to skip FTS creation
+    cleanly on FTS5-less builds) and by ``mindkeep doctor``.
+    """
+    try:
+        c = sqlite3.connect(":memory:")
+    except sqlite3.Error:
+        return False
+    try:
+        try:
+            c.execute("CREATE VIRTUAL TABLE _probe USING fts5(x)")
+            return True
+        except sqlite3.OperationalError:
+            return False
+    finally:
+        c.close()
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+# Per-table column additions introduced in v3. Idempotent: we only ALTER
+# what's actually missing, so re-running the migration on a v3 store is a
+# no-op.
+_V3_COLUMNS: dict[str, tuple[tuple[str, str], ...]] = {
+    "facts": (
+        ("last_accessed_at", "TEXT"),
+        ("access_count", "INTEGER NOT NULL DEFAULT 0"),
+        ("pin", "INTEGER NOT NULL DEFAULT 0"),
+        ("archived_at", "TEXT"),
+        ("token_estimate", "INTEGER"),
+    ),
+    "adrs": (
+        ("last_accessed_at", "TEXT"),
+        ("access_count", "INTEGER NOT NULL DEFAULT 0"),
+        ("pin", "INTEGER NOT NULL DEFAULT 0"),
+        ("archived_at", "TEXT"),
+        ("token_estimate", "INTEGER"),
+    ),
+    "meta": (
+        ("access_tracking_started_at", "TEXT"),
+    ),
+}
+
+
+def _populate_fts(conn: sqlite3.Connection) -> None:
+    """Backfill FTS rows from existing facts/adrs (idempotent)."""
+    fts_count = conn.execute(
+        "SELECT COUNT(*) FROM facts_fts"
+    ).fetchone()[0]
+    if fts_count == 0:
+        conn.execute(
+            "INSERT INTO facts_fts(rowid, value, tags) "
+            "SELECT rowid, value, tags FROM facts"
+        )
+    fts_count = conn.execute(
+        "SELECT COUNT(*) FROM adrs_fts"
+    ).fetchone()[0]
+    if fts_count == 0:
+        conn.execute(
+            "INSERT INTO adrs_fts(rowid, title, decision, context) "
+            "SELECT rowid, title, decision, context FROM adrs"
+        )
+
+
+def migrate_to_v3(
+    conn: sqlite3.Connection,
+    *,
+    fts_available: bool | None = None,
+) -> None:
+    """Idempotently bring a store up to schema v3.
+
+    Adds the salience columns (``last_accessed_at``, ``access_count``,
+    ``pin``, ``archived_at``, ``token_estimate``) to ``facts`` and ``adrs``,
+    plus ``access_tracking_started_at`` to ``meta``. Creates the
+    ``facts_fts``/``adrs_fts`` virtual tables and their sync triggers when
+    FTS5 is compiled in; logs a warning and skips otherwise. Backfills FTS
+    rows for any pre-existing content. Stamps ``schema_version = 3`` and
+    seeds ``access_tracking_started_at`` so future GC can distinguish rows
+    that pre-date access tracking from genuinely stale rows.
+
+    Safe to run on an already-v3 store: every step is a guarded
+    ``ADD COLUMN``/``CREATE … IF NOT EXISTS``/``UPDATE`` and the FTS
+    backfill skips when the FTS table is non-empty.
+    """
+    if fts_available is None:
+        fts_available = fts5_available()
+
+    conn.execute("BEGIN")
+    try:
+        for table, cols in _V3_COLUMNS.items():
+            existing = _table_columns(conn, table)
+            for name, decl in cols:
+                if name not in existing:
+                    conn.execute(
+                        f"ALTER TABLE {table} ADD COLUMN {name} {decl}"
+                    )
+
+        if fts_available:
+            for stmt in _FTS_DDL:
+                conn.execute(stmt)
+            _populate_fts(conn)
+        else:
+            _log.warning(
+                "SQLite build lacks FTS5 (ENABLE_FTS5 not in compile options); "
+                "skipping facts_fts/adrs_fts creation. Salience columns are "
+                "still present, but full-text search will be unavailable until "
+                "the user reinstalls a SQLite/Python with FTS5 enabled."
+            )
+
+        # Seed access_tracking_started_at exactly once: only if NULL.
+        conn.execute(
+            "UPDATE meta SET access_tracking_started_at = ? "
+            "WHERE id = 1 AND access_tracking_started_at IS NULL",
+            (_now_iso(),),
+        )
+        conn.execute(
+            "UPDATE meta SET schema_version = ?, updated_at = ? WHERE id = 1",
+            (SCHEMA_VERSION, _now_iso()),
+        )
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
 
 
 def default_data_dir() -> Path:
@@ -191,14 +404,18 @@ class Storage:
                 now = _now_iso()
                 self._conn.execute(
                     "INSERT OR IGNORE INTO meta "
-                    "(id, schema_version, project_id, created_at, updated_at) "
-                    "VALUES (1, ?, ?, ?, ?)",
-                    (SCHEMA_VERSION, project_hash, now, now),
+                    "(id, schema_version, project_id, "
+                    "access_tracking_started_at, created_at, updated_at) "
+                    "VALUES (1, ?, ?, ?, ?, ?)",
+                    (SCHEMA_VERSION, project_hash, now, now, now),
                 )
             self._conn.execute("COMMIT")
         except Exception:
             self._conn.execute("ROLLBACK")
             raise
+
+        # Bring legacy stores up to current schema. Idempotent on v3.
+        migrate_to_v3(self._conn)
 
         # Cache per-table allowed columns (P0-1 — column-name whitelist).
         # Populated from PRAGMA table_info; used to reject caller-supplied

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -240,3 +240,246 @@ def test_upsert_unknown_column_rejected(tmp_storage):
     row["bogus"] = "x"
     with pytest.raises(ValueError, match="unknown column"):
         s.upsert("preferences", row, conflict_cols=("key",))
+
+
+# ─────────────────────────────────────────────────────────────────────
+# v0.3.0 — schema v3 migration tests
+# ─────────────────────────────────────────────────────────────────────
+import sqlite3  # noqa: E402
+
+from mindkeep import storage as storage_mod  # noqa: E402
+from mindkeep.storage import fts5_available, migrate_to_v3  # noqa: E402
+
+
+_V3_FACT_COLS = {
+    "last_accessed_at",
+    "access_count",
+    "pin",
+    "archived_at",
+    "token_estimate",
+}
+_V3_ADR_COLS = _V3_FACT_COLS  # same set on adrs
+
+
+def _table_cols(conn, table):
+    return {r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def test_fresh_store_reports_schema_v3(tmp_path):
+    s = Storage(PROJECT_HASH, data_dir=tmp_path)
+    try:
+        assert SCHEMA_VERSION == 3
+        meta = s.query("meta")[0]
+        assert meta["schema_version"] == 3
+        # access_tracking_started_at seeded for fresh stores so future
+        # gc work can distinguish legacy NULL rows.
+        assert meta["access_tracking_started_at"]
+        # Every v3 column present on facts and adrs.
+        assert _V3_FACT_COLS <= _table_cols(s._conn, "facts")
+        assert _V3_ADR_COLS <= _table_cols(s._conn, "adrs")
+    finally:
+        s.close()
+
+
+def _build_v2_store(db_path):
+    """Hand-craft a pre-v3 store (the v1 schema this project shipped, with
+    schema_version=2 to simulate a v2 store) to exercise the migration."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE meta (
+            id              INTEGER PRIMARY KEY CHECK (id = 1),
+            schema_version  INTEGER NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT '',
+            display_name    TEXT    NOT NULL DEFAULT '',
+            id_source       TEXT    NOT NULL DEFAULT '',
+            origin_value    TEXT    NOT NULL DEFAULT '',
+            created_at      TEXT    NOT NULL,
+            updated_at      TEXT    NOT NULL
+        );
+        CREATE TABLE facts (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            key         TEXT    NOT NULL,
+            value       TEXT    NOT NULL,
+            tags        TEXT    NOT NULL DEFAULT '',
+            source      TEXT    NOT NULL DEFAULT 'agent',
+            confidence  REAL    NOT NULL DEFAULT 1.0,
+            created_at  TEXT    NOT NULL,
+            updated_at  TEXT    NOT NULL,
+            UNIQUE(key)
+        );
+        CREATE TABLE adrs (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            number       INTEGER NOT NULL,
+            title        TEXT    NOT NULL,
+            status       TEXT    NOT NULL,
+            context      TEXT    NOT NULL,
+            decision     TEXT    NOT NULL,
+            alternatives TEXT    NOT NULL DEFAULT '',
+            consequences TEXT    NOT NULL DEFAULT '',
+            supersedes   INTEGER,
+            tags         TEXT    NOT NULL DEFAULT '',
+            created_at   TEXT    NOT NULL,
+            updated_at   TEXT    NOT NULL,
+            UNIQUE(number),
+            FOREIGN KEY (supersedes) REFERENCES adrs(id)
+        );
+        CREATE TABLE session_summaries (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id    TEXT    NOT NULL,
+            summary       TEXT    NOT NULL,
+            files_touched TEXT    NOT NULL DEFAULT '',
+            refs          TEXT    NOT NULL DEFAULT '',
+            started_at    TEXT    NOT NULL,
+            ended_at      TEXT    NOT NULL,
+            created_at    TEXT    NOT NULL,
+            UNIQUE(session_id)
+        );
+        CREATE TABLE preferences (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            key         TEXT    NOT NULL UNIQUE,
+            value       TEXT    NOT NULL,
+            scope       TEXT    NOT NULL DEFAULT 'user',
+            created_at  TEXT    NOT NULL,
+            updated_at  TEXT    NOT NULL
+        );
+        INSERT INTO meta(id, schema_version, project_id, created_at, updated_at)
+            VALUES (1, 2, 'legacy', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z');
+        INSERT INTO facts(key, value, created_at, updated_at)
+            VALUES ('legacy.k1', 'v1', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z');
+        INSERT INTO facts(key, value, created_at, updated_at)
+            VALUES ('legacy.k2', 'v2', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z');
+        INSERT INTO adrs(number, title, status, context, decision,
+                         created_at, updated_at)
+            VALUES (1, 'Use SQLite', 'accepted', 'ctx', 'dec',
+                    '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_v2_to_v3_migration_preserves_data_and_adds_columns(tmp_path):
+    db_path = tmp_path / f"{PROJECT_HASH}.db"
+    _build_v2_store(db_path)
+    s = Storage(PROJECT_HASH, data_dir=tmp_path)
+    try:
+        meta = s.query("meta")[0]
+        assert meta["schema_version"] == 3
+        # Pre-existing meta fields preserved.
+        assert meta["project_id"] == "legacy"
+        # access_tracking_started_at seeded by migration so future gc work
+        # can distinguish legacy NULL last_accessed_at rows from stale ones.
+        assert meta["access_tracking_started_at"]
+        # All facts/adrs preserved.
+        assert {r["key"] for r in s.query("facts")} == {"legacy.k1", "legacy.k2"}
+        assert len(s.query("adrs")) == 1
+        # Defaults applied to legacy rows.
+        for fact in s.query("facts"):
+            assert fact["last_accessed_at"] is None
+            assert fact["access_count"] == 0
+            assert fact["pin"] == 0
+            assert fact["archived_at"] is None
+            assert fact["token_estimate"] is None
+        adr = s.query("adrs")[0]
+        assert adr["last_accessed_at"] is None
+        assert adr["access_count"] == 0
+    finally:
+        s.close()
+
+
+def test_migration_is_idempotent_on_v3(tmp_path):
+    s = Storage(PROJECT_HASH, data_dir=tmp_path)
+    try:
+        # Run again — must be a no-op (no exceptions, no duplicate triggers).
+        migrate_to_v3(s._conn)
+        migrate_to_v3(s._conn)
+
+        meta = s.query("meta")[0]
+        assert meta["schema_version"] == 3
+
+        # Triggers exist exactly once.
+        if fts5_available():
+            trigger_names = {
+                r[0]
+                for r in s._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='trigger'"
+                ).fetchall()
+            }
+            for expected in {
+                "facts_ai", "facts_ad", "facts_au",
+                "adrs_ai", "adrs_ad", "adrs_au",
+            }:
+                assert expected in trigger_names
+
+            # Re-running shouldn't re-populate the FTS table either —
+            # insert one row, run migrate again, count must stay at 1.
+            s.insert("facts", _fact_row("idem.k"))
+            count_before = s._conn.execute(
+                "SELECT COUNT(*) FROM facts_fts"
+            ).fetchone()[0]
+            migrate_to_v3(s._conn)
+            count_after = s._conn.execute(
+                "SELECT COUNT(*) FROM facts_fts"
+            ).fetchone()[0]
+            assert count_after == count_before
+    finally:
+        s.close()
+
+
+@pytest.mark.skipif(not fts5_available(),
+                    reason="SQLite build lacks FTS5")
+def test_fts5_search_smoke_including_cjk(tmp_path):
+    s = Storage(PROJECT_HASH, data_dir=tmp_path)
+    try:
+        s.insert("facts", {**_fact_row("auth.method"),
+                           "value": "use JWT RS256 for tokens"})
+        s.insert("facts", {**_fact_row("build.tool"),
+                           "value": "uv for dependency management"})
+        s.insert("facts", {**_fact_row("auth.cjk"),
+                           "value": "auth.method: 使用 JWT RS256"})
+
+        rows = s._conn.execute(
+            "SELECT rowid FROM facts_fts WHERE facts_fts MATCH ?",
+            ("JWT",),
+        ).fetchall()
+        assert len(rows) == 2
+
+        rows = s._conn.execute(
+            "SELECT rowid FROM facts_fts WHERE facts_fts MATCH ?",
+            ("使用",),
+        ).fetchall()
+        assert len(rows) == 1
+        # And the matched row is the CJK one.
+        cjk_rowid = rows[0][0]
+        match = s._conn.execute(
+            "SELECT key FROM facts WHERE rowid = ?", (cjk_rowid,)
+        ).fetchone()
+        assert match["key"] == "auth.cjk"
+    finally:
+        s.close()
+
+
+def test_migration_without_fts5_logs_warning_and_opens(tmp_path,
+                                                       monkeypatch, caplog):
+    monkeypatch.setattr(storage_mod, "fts5_available", lambda: False)
+    with caplog.at_level("WARNING", logger=storage_mod.__name__):
+        s = Storage(PROJECT_HASH, data_dir=tmp_path)
+        try:
+            # Store opens, schema is v3, salience columns present.
+            assert s.query("meta")[0]["schema_version"] == 3
+            assert _V3_FACT_COLS <= _table_cols(s._conn, "facts")
+            # FTS tables/triggers were skipped.
+            objs = {
+                r[0]
+                for r in s._conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type IN ('table', 'trigger')"
+                ).fetchall()
+            }
+            assert "facts_fts" not in objs
+            assert "facts_ai" not in objs
+        finally:
+            s.close()
+    assert any("FTS5" in rec.message for rec in caplog.records)
+


### PR DESCRIPTION
🚧 **DRAFT — do not merge before v0.3.0 design doc PR lands.**

## What this is

P0-1 of v0.3.0: the foundation schema bump that every other v0.3.0 PR (recall, stats, gc, doctor, etc. — #2/#3/#4/#6/#7/#8/#9) depends on.

**No behavior change yet.** Other PRs will use these columns and the FTS5 indices.

- Milestone: v0.3.0 (TBD — milestone not yet created)
- Design doc: TBD — link from the upcoming design doc PR

## DDL summary

### New columns (idempotent `ALTER TABLE ADD COLUMN`)

On `facts` **and** `adrs`:

| column             | type      | default | notes                                       |
|--------------------|-----------|---------|---------------------------------------------|
| `last_accessed_at` | TEXT      | NULL    | ISO timestamp; legacy rows = NULL           |
| `access_count`     | INTEGER   | 0       | NOT NULL                                    |
| `pin`              | INTEGER   | 0       | NOT NULL, 0/1                               |
| `archived_at`      | TEXT      | NULL    | ISO timestamp                               |
| `token_estimate`   | INTEGER   | NULL    | backfilled lazily / via `doctor --rebuild-stats` |

On `meta`:

| column                        | type | notes                                            |
|-------------------------------|------|--------------------------------------------------|
| `access_tracking_started_at`  | TEXT | seeded once on migration; lets future gc distinguish legacy NULL `last_accessed_at` from genuinely stale rows |

### New FTS5 virtual tables + sync triggers

- `facts_fts(value, tags, content=facts, content_rowid=rowid)` — `tokenize='unicode61 remove_diacritics 1'` (CJK-friendly).
- `adrs_fts(title, decision, context, content=adrs, content_rowid=rowid)` — same tokenizer.
- Triggers: `facts_ai`/`facts_ad`/`facts_au` and `adrs_ai`/`adrs_ad`/`adrs_au` (AFTER INSERT/DELETE/UPDATE).
- Backfill on first migration: `INSERT INTO …_fts(rowid, …) SELECT rowid, … FROM …`.

### Schema version

`meta.schema_version = 3` (this codebase shipped `schema_version = 1`; v2 never existed in `main`, so this is functionally a 1→3 migration. The migration is named `migrate_to_v3` and is written to be idempotent on any pre-3 store.)

## Skeptic-mandated guarantees

1. **Idempotent.** Re-running on a v3 store is a no-op — every step is `ALTER TABLE ADD COLUMN` (guarded by `PRAGMA table_info`), `CREATE … IF NOT EXISTS`, or a guarded `UPDATE`. Test: `test_migration_is_idempotent_on_v3`.
2. **Additive only.** No existing column is rewritten, no row is dropped, no table is rebuilt. Test: `test_v2_to_v3_migration_preserves_data_and_adds_columns` checks row counts and pre-existing meta fields.
3. **Legacy `last_accessed_at = NULL` is preserved**, and `access_tracking_started_at` is seeded so future gc can distinguish "we just don't know" from "stale".
4. **FTS5 optional.** If the running SQLite lacks FTS5, we log a clear warning and skip FTS creation; the store still opens and the salience columns are still applied. Test: `test_migration_without_fts5_logs_warning_and_opens`. A `mindkeep doctor` check helper is exposed as `storage.fts5_available()` for the upcoming doctor PR.

## Tests

`python -m pytest -q` — **163 passed**, 1 pre-existing flake (`test_crash.py::test_scenario7_concurrent_child_processes_commit_survives`, "database is locked" on concurrent Windows SQLite — exists on `main`, unrelated to this PR).

5 new tests:

- `test_fresh_store_reports_schema_v3` — fresh store, v3 immediately, columns present.
- `test_v2_to_v3_migration_preserves_data_and_adds_columns` — hand-built legacy store; row counts unchanged; defaults applied to legacy rows.
- `test_migration_is_idempotent_on_v3` — running twice is a no-op; FTS isn't re-populated; triggers exist exactly once.
- `test_fts5_search_smoke_including_cjk` — `MATCH 'JWT'` and `MATCH '使用'` both return correct rowids.
- `test_migration_without_fts5_logs_warning_and_opens` — store opens, warning logged, FTS objects absent.

## Deviations from the spec

The v0.3.0 task spec assumed `meta` was a key/value table. In `main`, `meta` is a singleton-row table (`id = 1`) with `schema_version` as an INTEGER column. To minimise blast radius this PR:

- Sets `schema_version` via `UPDATE meta SET schema_version = 3 WHERE id = 1` instead of `INSERT OR REPLACE INTO meta(key, value)`.
- Adds `access_tracking_started_at` as a column on the singleton meta row instead of a kv pair.

The spec also called the FTS columns `content`/`rationale`. We name them after the underlying source columns (`value` for facts; `title`/`decision`/`context` for adrs) so external-content lookups by FTS5 work without column-name aliasing. `MATCH` semantics are identical.

## Out of scope (follow-up PRs)

- No reads or writes use the new columns yet.
- No `mindkeep doctor` CLI command yet — the helper (`fts5_available()`) is exported for the upcoming doctor PR to consume.
- No `--rebuild-stats` for `token_estimate` yet.
