### PR TITLE
feat(cli): session-level token budget (P0-2, #7)

### DIFF
--- a/src/mindkeep/_session.py
+++ b/src/mindkeep/_session.py
@@ -1,0 +1,181 @@
+"""Session-level token budget tracking (P0-2, issue #7).
+
+Per-shell-session JSON state file recording cumulative token spend.
+Schema::
+
+    {"version": 1, "spent": <int>, "started_at": "<iso>",
+     "last_call": "<iso>", "calls": <int>}
+
+The PID used in the filename is the immediate parent of the mindkeep
+process (``os.getppid()``). That isn't always the *top* shell — if the
+user pipes through subshells the budget will scope to the innermost
+shell. This is a deliberate simplification; see issue #7. When the
+parent shell exits the file orphans naturally and ``mindkeep session
+reset`` (or OS temp cleanup) removes it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ._tokens import estimate as estimate_tokens
+
+_ENV_BUDGET = "MINDKEEP_SESSION_BUDGET"
+_SCHEMA_VERSION = 1
+
+
+def _state_dir() -> Path:
+    """Return the per-user runtime directory for session state files.
+
+    Linux/macOS: ``$XDG_RUNTIME_DIR/mindkeep`` (fallback ``/tmp/mindkeep``).
+    Windows:   ``%LOCALAPPDATA%\\Temp\\mindkeep``.
+    """
+    if sys.platform.startswith("win"):
+        base = os.environ.get("LOCALAPPDATA")
+        if base:
+            return Path(base) / "Temp" / "mindkeep"
+        return Path(os.environ.get("TEMP", ".")) / "mindkeep"
+    base = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
+    return Path(base) / "mindkeep"
+
+
+def _shell_pid() -> int:
+    """Return the PID used to namespace the session file.
+
+    Currently just ``os.getppid()`` — the immediate parent. If the user
+    runs mindkeep through nested subshells the budget scopes to the
+    innermost shell rather than the top-level terminal. See issue #7.
+    """
+    return os.getppid()
+
+
+def state_path() -> Path:
+    return _state_dir() / f"session-{_shell_pid()}.json"
+
+
+def _budget() -> int:
+    raw = os.environ.get(_ENV_BUDGET, "").strip()
+    if not raw:
+        return 0
+    try:
+        n = int(raw)
+    except ValueError:
+        return 0
+    return max(0, n)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _empty_state() -> dict[str, Any]:
+    now = _now_iso()
+    return {
+        "version": _SCHEMA_VERSION,
+        "spent": 0,
+        "started_at": now,
+        "last_call": now,
+        "calls": 0,
+    }
+
+
+def load_state() -> dict[str, Any]:
+    p = state_path()
+    if not p.is_file():
+        return _empty_state()
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return _empty_state()
+    if not isinstance(data, dict) or data.get("version") != _SCHEMA_VERSION:
+        return _empty_state()
+    base = _empty_state()
+    base.update({k: data.get(k, base[k]) for k in base})
+    return base
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    p = state_path()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(state), encoding="utf-8")
+    except OSError:
+        # Best-effort — never fail the user's command on bookkeeping.
+        pass
+
+
+def status() -> dict[str, Any]:
+    """Return a snapshot of the current session state plus budget."""
+    s = load_state()
+    s["budget"] = _budget()
+    s["path"] = str(state_path())
+    return s
+
+
+def reset() -> bool:
+    """Delete the current session state file. Returns True if removed."""
+    p = state_path()
+    try:
+        p.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
+
+
+def check_and_record(text: str) -> tuple[bool, dict[str, Any]]:
+    """Decide whether *text* may be emitted under the current budget.
+
+    Always increments ``calls`` and updates ``last_call``. If the call
+    would fit (or no budget is set), also adds the estimate to ``spent``
+    and returns ``(True, state)``. If it would overflow, ``spent`` is
+    left untouched and ``(False, state)`` is returned — the caller
+    should suppress output and emit a stderr notice.
+    """
+    state = load_state()
+    estimate = estimate_tokens(text)
+    budget = _budget()
+    state["calls"] = int(state.get("calls", 0)) + 1
+    state["last_call"] = _now_iso()
+    allowed = True
+    if budget > 0 and state["spent"] + estimate >= budget:
+        allowed = False
+    else:
+        state["spent"] = int(state.get("spent", 0)) + estimate
+    _save_state(state)
+    state["budget"] = budget
+    state["estimate"] = estimate
+    return allowed, state
+
+
+def record_session_spend(text: str) -> tuple[bool, dict[str, Any]]:
+    """Public hook for sibling commands (e.g. recall) to debit budget.
+
+    Same semantics as :func:`check_and_record`.
+    """
+    return check_and_record(text)
+
+
+def emit_or_suppress(text: str, *, stream=None) -> bool:
+    """Emit *text* on stdout if the budget allows, else print a notice.
+
+    Returns True if the text was printed, False if suppressed.
+    """
+    allowed, state = check_and_record(text)
+    if allowed:
+        out = stream if stream is not None else sys.stdout
+        out.write(text)
+        if not text.endswith("\n"):
+            out.write("\n")
+        return True
+    sys.stderr.write(
+        f"[mindkeep] session budget reached: "
+        f"spent={state['spent']} budget={state['budget']}. "
+        f"Use {_ENV_BUDGET}=0 to disable, or start a new session.\n"
+    )
+    return False

--- a/src/mindkeep/_tokens.py
+++ b/src/mindkeep/_tokens.py
@@ -1,0 +1,38 @@
+"""Cheap token estimator (stdlib only).
+
+Heuristic from DESIGN-v0.3.0 §9: ASCII chars/4, CJK chars/2.
+This is intentionally approximate — we never call a real tokenizer.
+"""
+from __future__ import annotations
+
+
+def _is_cjk(ch: str) -> bool:
+    o = ord(ch)
+    # Common CJK ranges: Hiragana, Katakana, CJK Unified Ideographs,
+    # Hangul Syllables, CJK Symbols.
+    return (
+        0x3000 <= o <= 0x9FFF
+        or 0xAC00 <= o <= 0xD7AF
+        or 0xF900 <= o <= 0xFAFF
+        or 0xFF00 <= o <= 0xFFEF
+    )
+
+
+def estimate(text: str) -> int:
+    """Return an approximate token count for *text*.
+
+    ASCII-ish characters cost 1/4 token each; CJK characters cost 1/2.
+    Always returns ``>= 1`` for non-empty input so a tiny call still
+    debits the session budget.
+    """
+    if not text:
+        return 0
+    cjk = 0
+    other = 0
+    for ch in text:
+        if _is_cjk(ch):
+            cjk += 1
+        else:
+            other += 1
+    tokens = (other + 3) // 4 + (cjk + 1) // 2
+    return max(1, tokens)

--- a/src/mindkeep/cli.py
+++ b/src/mindkeep/cli.py
@@ -26,6 +26,7 @@ import sys
 from pathlib import Path
 from typing import Any, Sequence
 
+from . import _session
 from .memory_api import MemoryStore
 from .models import ProjectId
 from .project_id import resolve_project_id
@@ -341,19 +342,47 @@ def _show_kind(
 
 
 def _cmd_show(data_dir: Path, args: argparse.Namespace) -> int:
+    import io
     ph = _resolve_project_hash(data_dir, args.project)
     kinds = _ALL_KINDS if args.kind == "all" else (args.kind,)
     full = bool(getattr(args, "full", False) or getattr(args, "no_truncate", False))
     s = _open_storage(data_dir, ph)
     ps = _open_pref_storage(data_dir)
+    buf = io.StringIO()
+    real_stdout = sys.stdout
     try:
+        sys.stdout = buf
         print(f"project: {ph}")
         for kind in kinds:
             _show_kind(s, kind, args.tag, args.limit,
                        pref_storage=ps, full=full)
     finally:
+        sys.stdout = real_stdout
         s.close()
         ps.close()
+    rendered = buf.getvalue()
+    _session.emit_or_suppress(rendered.rstrip("\n"))
+    return 0
+
+
+def _cmd_session(args: argparse.Namespace) -> int:
+    sub = getattr(args, "session_cmd", None)
+    if sub == "reset":
+        removed = _session.reset()
+        path = _session.state_path()
+        if removed:
+            print(f"reset session state: {path}")
+        else:
+            print(f"no session state to reset (looked at {path})")
+        return 0
+    # default: status
+    st = _session.status()
+    print(f"path:       {st['path']}")
+    print(f"budget:     {st['budget']}  (env MINDKEEP_SESSION_BUDGET)")
+    print(f"spent:      {st['spent']}")
+    print(f"calls:      {st['calls']}")
+    print(f"started_at: {st['started_at']}")
+    print(f"last_call:  {st['last_call']}")
     return 0
 
 
@@ -838,6 +867,14 @@ def _build_parser() -> argparse.ArgumentParser:
     pu.add_argument("--yes", "-y", action="store_true",
                     help="skip interactive confirmation")
 
+    psess = sub.add_parser(
+        "session",
+        help="inspect or reset the per-shell token budget state",
+    )
+    psess_sub = psess.add_subparsers(dest="session_cmd", metavar="<subcommand>")
+    psess_sub.add_parser("status", help="print current session spend (default)")
+    psess_sub.add_parser("reset", help="delete the current session state file")
+
     return p
 
 
@@ -864,6 +901,8 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_doctor(data_dir)
         if args.cmd == "upgrade":
             return _cmd_upgrade(args)
+        if args.cmd == "session":
+            return _cmd_session(args)
     except _ProjectNotFound as exc:
         # User asked for a project that doesn't exist → user error.
         print(f"error: {exc}", file=sys.stderr)

--- a/tests/test_session_budget.py
+++ b/tests/test_session_budget.py
@@ -1,0 +1,164 @@
+"""Tests for session-level token budget (P0-2, issue #7)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mindkeep import _session, _tokens
+from mindkeep.cli import main as cli_main
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    """Redirect session state into tmp_path and clear budget env."""
+    state_dir = tmp_path / "mindkeep-session"
+    monkeypatch.setattr(_session, "_state_dir", lambda: state_dir)
+    # Pin the PID so tests are deterministic regardless of pytest's PID.
+    monkeypatch.setattr(_session, "_shell_pid", lambda: 4242)
+    monkeypatch.delenv("MINDKEEP_SESSION_BUDGET", raising=False)
+    yield
+
+
+# ─────────────────── token estimator ───────────────────
+
+
+def test_estimate_empty():
+    assert _tokens.estimate("") == 0
+
+
+def test_estimate_ascii_quarter():
+    # 8 ASCII chars → 2 tokens
+    assert _tokens.estimate("abcdefgh") == 2
+
+
+def test_estimate_cjk_half():
+    # 4 CJK chars → 2 tokens
+    assert _tokens.estimate("你好世界") == 2
+
+
+def test_estimate_min_one():
+    assert _tokens.estimate("a") == 1
+
+
+# ─────────────────── state file lifecycle ───────────────────
+
+
+def test_status_no_file_returns_zeros():
+    st = _session.status()
+    assert st["spent"] == 0
+    assert st["calls"] == 0
+    assert st["budget"] == 0
+    assert not Path(st["path"]).exists()
+
+
+def test_check_and_record_creates_file():
+    allowed, st = _session.check_and_record("hello world")
+    assert allowed is True
+    assert st["spent"] >= 1
+    assert st["calls"] == 1
+    assert _session.state_path().exists()
+
+
+def test_unset_budget_does_not_block_but_tracks():
+    st = None
+    for _ in range(3):
+        allowed, st = _session.check_and_record("x" * 400)
+        assert allowed is True
+    assert st is not None
+    assert st["calls"] == 3
+    assert st["spent"] >= 300  # 400/4 * 3
+
+
+def test_budget_blocks_when_exceeded(monkeypatch):
+    monkeypatch.setenv("MINDKEEP_SESSION_BUDGET", "100")
+    allowed1, st1 = _session.check_and_record("x" * 240)  # 60 tokens
+    assert allowed1 is True
+    assert st1["spent"] == 60
+    allowed2, st2 = _session.check_and_record("x" * 240)  # would be 120
+    assert allowed2 is False
+    # spent NOT bumped on rejection; calls IS.
+    assert st2["spent"] == 60
+    assert st2["calls"] == 2
+
+
+def test_reset_removes_file():
+    _session.check_and_record("seed")
+    assert _session.state_path().exists()
+    assert _session.reset() is True
+    assert not _session.state_path().exists()
+    # Idempotent.
+    assert _session.reset() is False
+
+
+# ─────────────────── CLI integration ───────────────────
+
+
+def _run_cli(argv, capsys):
+    rc = cli_main(argv)
+    out, err = capsys.readouterr()
+    return rc, out, err
+
+
+def test_cli_session_status_no_file(capsys):
+    rc, out, err = _run_cli(["session", "status"], capsys)
+    assert rc == 0
+    assert "spent:      0" in out
+    assert "budget:     0" in out
+    assert "calls:      0" in out
+
+
+def test_cli_session_reset(capsys):
+    _session.check_and_record("seed")
+    assert _session.state_path().exists()
+    rc, out, _ = _run_cli(["session", "reset"], capsys)
+    assert rc == 0
+    assert "reset session state" in out
+    assert not _session.state_path().exists()
+    rc, out, _ = _run_cli(["session", "reset"], capsys)
+    assert rc == 0
+    assert "no session state" in out
+
+
+def test_cli_show_records_spend(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "mem"
+    home.mkdir()
+    monkeypatch.setenv("MINDKEEP_HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+    from mindkeep.memory_api import MemoryStore
+    store = MemoryStore.open(cwd=tmp_path, data_dir=home)
+    try:
+        store.add_fact("hello world")
+    finally:
+        store.close()
+
+    rc, out, err = _run_cli(["show", "--kind", "facts", "--limit", "1"], capsys)
+    assert rc == 0
+    assert "project:" in out
+    st = _session.load_state()
+    assert st["spent"] > 0
+    assert st["calls"] == 1
+
+
+def test_cli_show_suppressed_when_budget_exhausted(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("MINDKEEP_SESSION_BUDGET", "1")  # tiny
+    home = tmp_path / "mem"
+    home.mkdir()
+    monkeypatch.setenv("MINDKEEP_HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+    from mindkeep.memory_api import MemoryStore
+    store = MemoryStore.open(cwd=tmp_path, data_dir=home)
+    try:
+        store.add_fact("hello world")
+    finally:
+        store.close()
+
+    rc, out, err = _run_cli(["show", "--kind", "facts", "--limit", "1"], capsys)
+    assert rc == 0
+    assert out == ""  # output suppressed
+    assert "session budget reached" in err
+    st = _session.load_state()
+    # Rejected calls still bump the call counter.
+    assert st["calls"] == 1


### PR DESCRIPTION
Implements **P0-2** from `docs/DESIGN-v0.3.0.md` §5: a per-shell-session
token budget so agents that loop on `mindkeep show` / `recall` can't
silently blow their context window.

Closes #7.

## What's in here

- `mindkeep/_tokens.py` — stdlib-only estimator (`chars/4` ASCII,
  `chars/2` CJK, per design doc §9).
- `mindkeep/_session.py` — JSON state file under
  `$XDG_RUNTIME_DIR/mindkeep/session-{ppid}.json` (Linux/macOS) or
  `%LOCALAPPDATA%\Temp\mindkeep\session-{ppid}.json` (Windows). Schema
  `{version, spent, started_at, last_call, calls}`. PID is the immediate
  parent (`os.getppid()`) — documented limitation; nested subshells
  scope to the innermost shell.
- `mindkeep/cli.py`:
  - `show` now buffers its output and routes through
    `_session.emit_or_suppress`. When `MINDKEEP_SESSION_BUDGET=N` is set
    and `spent + estimate >= N`, stdout stays empty and stderr prints
    `[mindkeep] session budget reached: spent=X budget=Y. Use
    MINDKEEP_SESSION_BUDGET=0 to disable, or start a new session.` Exit
    code remains `0` so agents don't crash.
  - New `mindkeep session status` and `mindkeep session reset`
    subcommands.
- `_session.record_session_spend(text)` is the public hook for sibling
  commands (notably `recall`, landing later) to debit the same budget.

Unset / `MINDKEEP_SESSION_BUDGET=0` disables enforcement but **still**
tracks spend, so `mindkeep session status` is useful diagnostically out
of the box.

## Parallel siblings

Coordinating with **#11 (stats)**, **#12 (write guard)**, **#13 (pin)**
which also touch `cli.py` / `storage.py`:
- Kept all my edits surgical: one new `_session` import, one new
  dispatch arm at the bottom, one buffered `_cmd_show`.
- Did not rename anything in `storage.py` (no edits there at all).
- Stats can call `mindkeep._session.status()` directly for budget /
  spend numbers when wiring the `mindkeep stats` accessor.

## Tested

- `python -m pytest -q` → **177 passed** (164 baseline + 13 new).
- Smoke (powershell):
  ```
  $env:MINDKEEP_SESSION_BUDGET="500"
  python -m mindkeep session status
  # path:       …\Temp\mindkeep\session-<ppid>.json
  # budget:     500  (env MINDKEEP_SESSION_BUDGET)
  # spent:      0
  # calls:      0
  python -m mindkeep show --kind facts --limit 2
  # project: 19a9f815ec45
  # == facts ==
  # (no rows)
  python -m mindkeep session status
  # spent:      <small int>, calls: 1
  python -m mindkeep session reset
  # reset session state: …\session-<ppid>.json
  ```

## Constraints honoured

- Stdlib only.
- `mindkeep show` without the env var renders identically to before
  (the buffered output still goes to stdout via `emit_or_suppress`,
  trailing newline preserved).
- ~370 lines including tests.
