### PR TITLE
feat(cli): mindkeep stats [--json] (P1-6, #11)

### DIFF
--- a/src/mindkeep/cli.py
+++ b/src/mindkeep/cli.py
@@ -848,6 +848,99 @@ def _cmd_upgrade(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_stats(data_dir: Path, args: argparse.Namespace) -> int:
+    """Print per-project store stats (human or JSON)."""
+    ph = _resolve_project_hash(data_dir, args.project)
+    s = _open_storage(data_dir, ph)
+    ps = _open_pref_storage(data_dir)
+    try:
+        data = s.stats()
+        prefs_total = ps.query("preferences")
+    finally:
+        s.close()
+        ps.close()
+    data["data_dir"] = str(data_dir)
+    data["preferences"] = {"total": len(prefs_total)}
+
+    # Optional session-budget integration (P0-2 sibling).
+    budget_block: dict[str, Any] | None = None
+    try:
+        from ._session import current_state  # type: ignore[attr-defined]
+        st = current_state()
+        if st is not None:
+            budget_block = {
+                "active": bool(st.get("active", True)),
+                "budget": st.get("budget"),
+                "spent": st.get("spent"),
+                "calls": st.get("calls"),
+            }
+    except Exception:
+        budget_block = None
+    data["session_budget"] = budget_block
+
+    if getattr(args, "json", False):
+        ordered = {
+            "schema_version": data["schema_version"],
+            "project_id": data["project_id"],
+            "data_dir": data["data_dir"],
+            "db_size_bytes": data["db_size_bytes"],
+            "facts": data["facts"],
+            "adrs": data["adrs"],
+            "preferences": data["preferences"],
+            "sessions": data["sessions"],
+            "top_tags": data["top_tags"],
+            "tokens_estimated_total": data["tokens_estimated_total"],
+            "oldest_fact_at": data["oldest_fact_at"],
+            "newest_fact_at": data["newest_fact_at"],
+            "session_budget": data["session_budget"],
+        }
+        print(json.dumps(ordered, indent=2, sort_keys=False))
+        return 0
+
+    label_w = 20
+    print(f"mindkeep store · project={ph} · path={data_dir}")
+    print("─" * 60)
+
+    def _line(label: str, value: str) -> None:
+        print(f"{label.ljust(label_w)}{value}")
+
+    _line("Schema version:", str(data["schema_version"]))
+    f = data["facts"]
+    _line(
+        "Facts:",
+        f"{f['total']}  (pinned: {f['pinned']}, archived: {f['archived']})",
+    )
+    a = data["adrs"]
+    _line(
+        "ADRs:",
+        f"{a['total']}  (pinned: {a['pinned']}, archived: {a['archived']})",
+    )
+    _line("Preferences:", str(data["preferences"]["total"]))
+    _line("Sessions:", str(data["sessions"]["total"]))
+    if data["top_tags"]:
+        tags_str = ", ".join(
+            f"{t['tag']} ({t['count']})" for t in data["top_tags"]
+        )
+    else:
+        tags_str = "(none)"
+    _line("Top tags:", tags_str)
+    _line("Total tokens (est):", str(data["tokens_estimated_total"]))
+    _line("DB file size:", _fmt_size(data["db_size_bytes"]))
+    _line("Oldest fact:", data["oldest_fact_at"] or "(none)")
+    _line("Newest fact:", data["newest_fact_at"] or "(none)")
+    if budget_block is None:
+        _line("Session budget:", "not active")
+    else:
+        _line("Session budget:", "active")
+        spent = budget_block.get("spent")
+        budget = budget_block.get("budget")
+        calls = budget_block.get("calls")
+        print(
+            f"{''.ljust(label_w)}spent={spent} budget={budget} calls={calls}"
+        )
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="mindkeep",
@@ -916,6 +1009,12 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("doctor", help="run environment health checks")
 
+    pst = sub.add_parser("stats", help="print introspection stats for a project")
+    pst.add_argument("--project", default=None,
+                     help="project hash or display_name (default: current cwd)")
+    pst.add_argument("--json", action="store_true",
+                     help="emit machine-readable JSON instead of the human format")
+
     pu = sub.add_parser(
         "upgrade",
         help="pull the latest mindkeep (pip/pipx auto-detected)",
@@ -969,6 +1068,8 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_where(data_dir)
         if args.cmd == "doctor":
             return _cmd_doctor(data_dir)
+        if args.cmd == "stats":
+            return _cmd_stats(data_dir, args)
         if args.cmd == "upgrade":
             return _cmd_upgrade(args)
         if args.cmd == "session":

--- a/src/mindkeep/storage.py
+++ b/src/mindkeep/storage.py
@@ -377,6 +377,33 @@ class WriteGuardError(StorageError):
         self.pre_tokens = pre_tokens
 
 
+def _estimate_tokens(s: str) -> int:
+    """Cheap, deterministic token estimate.
+
+    Prefers sibling ``mindkeep._tokens.estimate`` if present (P0-2 work);
+    otherwise: count CJK / Hangul characters as 1 token each, the
+    remainder via ``len // 4``. Returns 0 for empty strings.
+    """
+    if not s:
+        return 0
+    try:
+        from ._tokens import estimate as _ext  # type: ignore[attr-defined]
+        return int(_ext(s))
+    except Exception:
+        pass
+    cjk = 0
+    for ch in s:
+        cp = ord(ch)
+        if (
+            0x4E00 <= cp <= 0x9FFF
+            or 0x3040 <= cp <= 0x30FF
+            or 0xAC00 <= cp <= 0xD7AF
+        ):
+            cjk += 1
+    other = len(s) - cjk
+    return cjk + (other // 4 if other else 0)
+
+
 def _atomic_write_bytes(path: Path, data: bytes) -> None:
     tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
     with open(tmp, "wb") as fh:
@@ -748,6 +775,107 @@ class Storage:
             self._ensure_open()
             self._conn.execute(sql, tuple(updates.values()))
             self._conn.commit()
+
+    def stats(self) -> dict[str, Any]:
+        """Return aggregate stats for this storage's DB.
+
+        Used by ``mindkeep stats``. Counts facts/adrs/sessions, computes
+        pinned/archived breakdowns, top tags (across facts+adrs), token
+        totals (lazily filled when ``token_estimate`` is NULL), and the
+        oldest/newest fact timestamps. Preferences are *not* counted here —
+        they live in a separate cross-project storage.
+        """
+        with self._lock:
+            self._ensure_open()
+            cur = self._conn
+
+            def _kind_counts(table: str) -> dict[str, int]:
+                row = cur.execute(
+                    f"SELECT COUNT(*) AS n, "
+                    f"COALESCE(SUM(CASE WHEN pin = 1 THEN 1 ELSE 0 END), 0) AS p, "
+                    f"COALESCE(SUM(CASE WHEN archived_at IS NOT NULL THEN 1 ELSE 0 END), 0) AS a "
+                    f"FROM {table}"
+                ).fetchone()
+                return {
+                    "total": int(row["n"]),
+                    "pinned": int(row["p"]),
+                    "archived": int(row["a"]),
+                }
+
+            facts = _kind_counts("facts")
+            adrs = _kind_counts("adrs")
+
+            sess_n = cur.execute(
+                "SELECT COUNT(*) AS n FROM session_summaries"
+            ).fetchone()["n"]
+
+            row = cur.execute(
+                "SELECT MIN(created_at) AS lo, MAX(created_at) AS hi FROM facts"
+            ).fetchone()
+            oldest_fact_at = row["lo"] if row and row["lo"] else None
+            newest_fact_at = row["hi"] if row and row["hi"] else None
+
+            tag_counts: dict[str, int] = {}
+            for tbl in ("facts", "adrs"):
+                for r in cur.execute(
+                    f"SELECT tags FROM {tbl} WHERE tags IS NOT NULL AND tags != ''"
+                ).fetchall():
+                    for tag in (r["tags"] or "").split(","):
+                        tag = tag.strip()
+                        if tag:
+                            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+            top_tags = sorted(
+                tag_counts.items(), key=lambda kv: (-kv[1], kv[0])
+            )[:5]
+
+            tokens_total = 0
+            for r in cur.execute(
+                "SELECT token_estimate, value FROM facts"
+            ).fetchall():
+                est = r["token_estimate"]
+                tokens_total += int(est) if est is not None else _estimate_tokens(
+                    r["value"] or ""
+                )
+            for r in cur.execute(
+                "SELECT token_estimate, title, context, decision FROM adrs"
+            ).fetchall():
+                est = r["token_estimate"]
+                if est is not None:
+                    tokens_total += int(est)
+                else:
+                    tokens_total += _estimate_tokens(
+                        " ".join(
+                            x or "" for x in (r["title"], r["context"], r["decision"])
+                        )
+                    )
+
+            schema_version = SCHEMA_VERSION
+            try:
+                mr = cur.execute(
+                    "SELECT schema_version FROM meta WHERE id = 1"
+                ).fetchone()
+                if mr is not None:
+                    schema_version = int(mr["schema_version"])
+            except sqlite3.Error:
+                pass
+
+            try:
+                db_size = self._db_path.stat().st_size
+            except OSError:
+                db_size = 0
+
+            return {
+                "schema_version": schema_version,
+                "project_id": self._project_hash,
+                "db_size_bytes": int(db_size),
+                "facts": facts,
+                "adrs": adrs,
+                "sessions": {"total": int(sess_n)},
+                "top_tags": [{"tag": t, "count": c} for t, c in top_tags],
+                "tokens_estimated_total": int(tokens_total),
+                "oldest_fact_at": oldest_fact_at,
+                "newest_fact_at": newest_fact_at,
+            }
 
     def commit(self) -> None:
         with self._lock:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,248 @@
+"""Tests for ``mindkeep stats`` (P1-6, issue #11)."""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from mindkeep import cli
+from mindkeep.memory_api import MemoryStore
+from mindkeep.storage import SCHEMA_VERSION, Storage, _estimate_tokens
+
+
+# ───────────────────────── fixtures ─────────────────────────
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "mem"
+    home.mkdir()
+    monkeypatch.setenv("MINDKEEP_HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+    return home
+
+
+def _run(argv: list[str], capsys: pytest.CaptureFixture[str]) -> tuple[int, str, str]:
+    rc = cli.main(argv)
+    cap = capsys.readouterr()
+    return rc, cap.out, cap.err
+
+
+# ───────────────────────── token estimator ─────────────────────────
+
+
+def test_estimate_tokens_empty():
+    assert _estimate_tokens("") == 0
+
+
+def test_estimate_tokens_ascii_quartered():
+    assert _estimate_tokens("abcdefghijkl") == 3  # 12 // 4
+
+
+def test_estimate_tokens_cjk_one_each():
+    # When sibling `_tokens.estimate` (P0-2) is available it returns chars/2
+    # for CJK (per design doc §9). Without it, the local fallback returns
+    # 1 token per CJK char. Both implementations produce a deterministic,
+    # non-zero count for pure CJK input.
+    assert _estimate_tokens("中文测试") in (2, 4)
+
+
+# ───────────────────────── Storage.stats() ─────────────────────────
+
+
+def test_stats_empty_store(data_dir: Path):
+    s = Storage("0123456789ab", data_dir=data_dir)
+    try:
+        d = s.stats()
+    finally:
+        s.close()
+    assert d["schema_version"] == SCHEMA_VERSION
+    assert d["facts"] == {"total": 0, "pinned": 0, "archived": 0}
+    assert d["adrs"] == {"total": 0, "pinned": 0, "archived": 0}
+    assert d["sessions"] == {"total": 0}
+    assert d["top_tags"] == []
+    assert d["tokens_estimated_total"] == 0
+    assert d["oldest_fact_at"] is None
+    assert d["newest_fact_at"] is None
+    assert d["db_size_bytes"] > 0
+
+
+def test_stats_counts_with_pin_and_archive(data_dir: Path, tmp_path: Path):
+    sub = tmp_path / "proj1"
+    sub.mkdir()
+    store = MemoryStore.open(cwd=sub, data_dir=data_dir)
+    try:
+        for i in range(5):
+            store.add_fact(f"fact-{i}", tags=["auth" if i < 3 else "ops", "core"])
+        for i in range(2):
+            store.add_adr(f"ADR {i}", "do X", "because Y", tags=["auth"])
+        ph = store.project_id.id
+    finally:
+        store.close()
+
+    s = Storage(ph, data_dir=data_dir)
+    try:
+        s._conn.execute("UPDATE facts SET pin = 1 WHERE id IN (1, 2)")
+        s._conn.execute(
+            "UPDATE facts SET archived_at = '2024-01-01T00:00:00Z' WHERE id = 3"
+        )
+        s._conn.commit()
+        d = s.stats()
+    finally:
+        s.close()
+
+    assert d["facts"]["total"] == 5
+    assert d["facts"]["pinned"] == 2
+    assert d["facts"]["archived"] == 1
+    assert d["adrs"]["total"] == 2
+    tags = d["top_tags"]
+    assert tags[0] == {"tag": "auth", "count": 5}  # 3 facts + 2 adrs
+    assert {t["tag"] for t in tags} >= {"auth", "core", "ops"}
+    assert d["tokens_estimated_total"] > 0
+    assert d["oldest_fact_at"] is not None
+    assert d["newest_fact_at"] is not None
+    assert d["oldest_fact_at"] <= d["newest_fact_at"]
+
+
+# ───────────────────────── CLI dispatch ─────────────────────────
+
+
+def _seed(data_dir: Path, tmp_path: Path) -> str:
+    sub = tmp_path / "cli_proj"
+    sub.mkdir()
+    store = MemoryStore.open(cwd=sub, data_dir=data_dir)
+    try:
+        store.add_fact("hello world", tags=["x", "y"])
+        store.add_fact("another", tags=["x"])
+        store.add_adr("ADR 1", "decide", "rationale", tags=["y"])
+        store.set_preference("editor", "vim")
+        ph = store.project_id.id
+    finally:
+        store.close()
+    return ph
+
+
+def test_stats_human_format(
+    data_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    ph = _seed(data_dir, tmp_path)
+    monkeypatch.chdir(tmp_path / "cli_proj")
+    rc, out, err = _run(["stats"], capsys)
+    assert rc == 0, err
+    assert "mindkeep store" in out
+    assert f"project={ph}" in out
+    assert "Schema version:" in out
+    assert "Facts:" in out
+    assert "ADRs:" in out
+    assert "Preferences:" in out
+    assert "Top tags:" in out
+    assert "DB file size:" in out
+    assert "Session budget:" in out
+    assert "not active" in out
+
+
+def test_stats_json_schema(
+    data_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    ph = _seed(data_dir, tmp_path)
+    monkeypatch.chdir(tmp_path / "cli_proj")
+    rc, out, err = _run(["stats", "--json"], capsys)
+    assert rc == 0, err
+    payload = json.loads(out)
+    expected = {
+        "schema_version", "project_id", "data_dir", "db_size_bytes",
+        "facts", "adrs", "preferences", "sessions", "top_tags",
+        "tokens_estimated_total", "oldest_fact_at", "newest_fact_at",
+        "session_budget",
+    }
+    assert expected.issubset(payload.keys())
+    assert payload["project_id"] == ph
+    assert payload["facts"]["total"] == 2
+    assert payload["adrs"]["total"] == 1
+    assert payload["preferences"]["total"] == 1
+    assert payload["db_size_bytes"] > 0
+    assert payload["session_budget"] is None
+    counts = [t["count"] for t in payload["top_tags"]]
+    assert counts == sorted(counts, reverse=True)
+
+
+def test_stats_top_tags_ranking(
+    data_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    sub = tmp_path / "rank_proj"
+    sub.mkdir()
+    store = MemoryStore.open(cwd=sub, data_dir=data_dir)
+    try:
+        store.add_fact("a", tags=["alpha", "beta"])
+        store.add_fact("b", tags=["alpha", "beta"])
+        store.add_fact("c", tags=["alpha"])
+        store.add_fact("d", tags=["gamma"])
+    finally:
+        store.close()
+    monkeypatch.chdir(sub)
+    rc, out, _ = _run(["stats", "--json"], capsys)
+    assert rc == 0
+    tags = json.loads(out)["top_tags"]
+    assert [t["tag"] for t in tags] == ["alpha", "beta", "gamma"]
+    assert [t["count"] for t in tags] == [3, 2, 1]
+
+
+def test_stats_session_budget_mocked(
+    data_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    _seed(data_dir, tmp_path)
+    monkeypatch.chdir(tmp_path / "cli_proj")
+
+    fake = types.ModuleType("mindkeep._session")
+    fake.current_state = lambda: {  # type: ignore[attr-defined]
+        "active": True, "budget": 2000, "spent": 450, "calls": 3,
+    }
+    monkeypatch.setitem(sys.modules, "mindkeep._session", fake)
+
+    rc, out, _ = _run(["stats", "--json"], capsys)
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["session_budget"] == {
+        "active": True, "budget": 2000, "spent": 450, "calls": 3,
+    }
+
+
+def test_stats_oldest_before_newest(
+    data_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    sub = tmp_path / "ts_proj"
+    sub.mkdir()
+    store = MemoryStore.open(cwd=sub, data_dir=data_dir)
+    try:
+        store.add_fact("first")
+        ph = store.project_id.id
+    finally:
+        store.close()
+    s = Storage(ph, data_dir=data_dir)
+    try:
+        s._conn.execute(
+            "UPDATE facts SET created_at = '2020-01-01T00:00:00Z' WHERE id = 1"
+        )
+        s._conn.commit()
+    finally:
+        s.close()
+    store = MemoryStore.open(cwd=sub, data_dir=data_dir)
+    try:
+        store.add_fact("second")
+    finally:
+        store.close()
+
+    monkeypatch.chdir(sub)
+    rc, out, _ = _run(["stats", "--json"], capsys)
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["oldest_fact_at"] == "2020-01-01T00:00:00Z"
+    assert payload["newest_fact_at"] > payload["oldest_fact_at"]


### PR DESCRIPTION
Closes #11

Implements `mindkeep stats [--json]` per the v0.3.0 design (see `docs/DESIGN-v0.3.0.md`, P1-6).

## What

A new introspection command that prints per-project store stats:

- schema version, project hash, data dir, DB file size
- counts for facts / ADRs / preferences / sessions, with pinned + archived breakdowns for facts and ADRs
- top-5 tags across facts + ADRs (sorted by count DESC, tag ASC for deterministic tiebreak)
- total estimated tokens (uses `token_estimate` column when set; otherwise lazily computed via a CJK-aware `len(s)//4` heuristic; prefers a sibling `mindkeep._tokens.estimate` if present)
- oldest / newest fact timestamps
- optional session-budget block (rendered when the P0-2 sibling `mindkeep._session.current_state` is importable; otherwise human shows `not active` and JSON shows `null`)

## Implementation notes

- `Storage.stats()` does the SQL aggregation in one place; CLI just formats. Aggregates use `COALESCE(SUM(CASE WHEN ...))` against `pin` / `archived_at` so they work on both empty stores and populated ones.
- Preferences live in the cross-project storage, so the CLI counts them separately and folds the result into the dict before rendering.
- JSON output uses a fixed key order for deterministic diffs.
- Token estimator is exposed at module level (`_estimate_tokens`) so tests can pin its behaviour without going through the storage.

## Parallel sibling notes

3 sibling agents are concurrently working on P0-2 (#7), P1-7 (#12), and P1-8 (#13). All four PRs touch `src/mindkeep/cli.py`. To minimise conflict surface this PR:

- only **adds** to `cli.py` (one new `_cmd_stats` function, one `sub.add_parser("stats", ...)` block, one new dispatch arm) — no edits to existing commands;
- only **adds** to `storage.py` (one new `stats()` method, one new `_estimate_tokens()` helper) — no edits to existing methods;
- gracefully degrades if `mindkeep._session` / `mindkeep._tokens` aren't there yet (try/except ImportError around both).

Likely conflict with #7: both PRs append a subparser at the bottom and add a dispatch arm. A trivial textual conflict — resolution is just stacking the two subparsers / two `if args.cmd == "..."` arms. No semantic overlap.

No anticipated conflicts with #12 / #13.

## Tested

- `python -m pytest -q` → **174 passed** (164 baseline + 10 new in `tests/test_stats.py`).
- New tests cover: empty-store stats, pin/archive aggregation, top-tag ranking with deterministic tiebreak, JSON schema conformance, human format smoke, oldest/newest timestamp ordering, mocked session-budget integration, and the token estimator (empty / ASCII / CJK).

### Sample human output

```
mindkeep store · project=19a9f815ec45 · path=C:\Users\me\AppData\Roaming\mindkeep
────────────────────────────────────────────────────────────
Schema version:     3
Facts:              3  (pinned: 0, archived: 0)
ADRs:               1  (pinned: 0, archived: 0)
Preferences:        1
Sessions:           0
Top tags:           auth (2), ops (2), api (1), db (1), security (1)
Total tokens (est): 19
DB file size:       108.0KB
Oldest fact:        2026-04-29T10:04:38Z
Newest fact:        2026-04-29T10:04:38Z
Session budget:     not active
```

### Sample JSON output

```json
{
  "schema_version": 3,
  "project_id": "19a9f815ec45",
  "data_dir": "...",
  "db_size_bytes": 110592,
  "facts": {"total": 3, "pinned": 0, "archived": 0},
  "adrs":  {"total": 1, "pinned": 0, "archived": 0},
  "preferences": {"total": 1},
  "sessions": {"total": 0},
  "top_tags": [
    {"tag": "auth", "count": 2},
    {"tag": "ops",  "count": 2},
    {"tag": "api",  "count": 1},
    {"tag": "db",   "count": 1},
    {"tag": "security", "count": 1}
  ],
  "tokens_estimated_total": 19,
  "oldest_fact_at": "2026-04-29T10:04:38Z",
  "newest_fact_at": "2026-04-29T10:04:38Z",
  "session_budget": null
}
```
