### PR TITLE
feat(api,cli): pin/unpin facts and ADRs (P1-8, #13)

### DIFF
--- a/src/mindkeep/cli.py
+++ b/src/mindkeep/cli.py
@@ -258,6 +258,7 @@ def _show_kind(
     storage: Storage, kind: str, tag: str | None, limit: int,
     pref_storage: Storage | None = None,
     full: bool = False,
+    pinned_only: bool = False,
 ) -> None:
     # In ``--full`` mode, large free-text columns render raw (newlines
     # preserved, no width cap). Alignment is sacrificed; see PRD-ux-polish.
@@ -272,15 +273,26 @@ def _show_kind(
     else:
         rows = storage.query(table)
 
+    if pinned_only and kind in ("facts", "adrs"):
+        rows = [r for r in rows if int(r.get("pin") or 0) == 1]
+
     if kind == "facts":
-        rows.sort(key=lambda r: r.get("updated_at", ""), reverse=True)
+        rows.sort(
+            key=lambda r: (
+                int(r.get("pin") or 0),
+                r.get("created_at", ""),
+                int(r.get("id") or 0),
+            ),
+            reverse=True,
+        )
         if tag:
             rows = [r for r in rows if tag in _tags_list(r.get("tags", ""))]
         rows = rows[: max(0, limit)]
-        headers = ["id", "key", "value", "tags", "updated_at"]
+        headers = ["id", "pin", "key", "value", "tags", "updated_at"]
         data = [
             [
                 str(r["id"]),
+                "*" if int(r.get("pin") or 0) == 1 else "",
                 _trunc(r.get("key", "")),
                 _cell(r.get("value", "")),
                 _trunc(r.get("tags", "")),
@@ -289,14 +301,22 @@ def _show_kind(
             for r in rows
         ]
     elif kind == "adrs":
-        rows.sort(key=lambda r: int(r.get("number", 0)))
+        rows.sort(
+            key=lambda r: (
+                int(r.get("pin") or 0),
+                r.get("created_at", ""),
+                int(r.get("id") or 0),
+            ),
+            reverse=True,
+        )
         if tag:
             rows = [r for r in rows if tag in _tags_list(r.get("tags", ""))]
         rows = rows[: max(0, limit)]
-        headers = ["number", "title", "status", "decision", "tags", "updated_at"]
+        headers = ["number", "pin", "title", "status", "decision", "tags", "updated_at"]
         data = [
             [
                 str(r.get("number", "")),
+                "*" if int(r.get("pin") or 0) == 1 else "",
                 _trunc(r.get("title", "")),
                 _trunc(r.get("status", ""), 16),
                 _cell(r.get("decision", "")),
@@ -355,7 +375,8 @@ def _cmd_show(data_dir: Path, args: argparse.Namespace) -> int:
         print(f"project: {ph}")
         for kind in kinds:
             _show_kind(s, kind, args.tag, args.limit,
-                       pref_storage=ps, full=full)
+                       pref_storage=ps, full=full,
+                       pinned_only=bool(getattr(args, "pinned", False)))
     finally:
         sys.stdout = real_stdout
         s.close()
@@ -416,6 +437,37 @@ def _cmd_clear(data_dir: Path, args: argparse.Namespace) -> int:
     finally:
         store.close()
     print(f"cleared {total} rows from {ph}")
+    return 0
+
+
+# ───────────────────────── command: pin / unpin ─────────────────────────
+
+
+_PIN_KIND_TABLE: dict[str, str] = {"fact": "facts", "adr": "adrs"}
+
+
+def _cmd_pin(data_dir: Path, args: argparse.Namespace, *, value: int) -> int:
+    """Set or clear ``pin`` on a single fact or ADR row (P1-8)."""
+    ph = _resolve_project_hash(data_dir, args.project)
+    table = _PIN_KIND_TABLE[args.kind]
+    s = _open_storage(data_dir, ph)
+    try:
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        n = s.update(
+            table,
+            where={"id": int(args.id)},
+            values={"pin": value, "updated_at": now},
+        )
+    finally:
+        s.close()
+    if n == 0:
+        verb = "pin" if value else "unpin"
+        print(f"error: cannot {verb}: {args.kind} id {args.id} not found in {ph}",
+              file=sys.stderr)
+        return 2
+    state = "pinned" if value else "unpinned"
+    print(f"{state} {args.kind} {args.id} in {ph}")
     return 0
 
 
@@ -818,6 +870,10 @@ def _build_parser() -> argparse.ArgumentParser:
     ps.add_argument("--tag", default=None)
     ps.add_argument("--limit", type=int, default=20)
     ps.add_argument(
+        "--pinned", action="store_true",
+        help="only show pinned facts/ADRs (P1-8)",
+    )
+    ps.add_argument(
         "--full", "--no-truncate",
         dest="full", action="store_true",
         help="print full values without the default ~52-char truncation "
@@ -832,6 +888,16 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     pc.add_argument("--yes", action="store_true",
                     help="skip confirmation prompt")
+
+    for verb, helptext in (("pin",   "pin a fact or ADR so it surfaces first"),
+                           ("unpin", "remove the pinned flag from a fact or ADR")):
+        pp = sub.add_parser(verb, help=helptext)
+        pp.add_argument("--project", default=None,
+                        help="project hash or display_name (default: current cwd)")
+        pp.add_argument("kind", choices=["fact", "adr"], metavar="<kind>",
+                        help="row type: fact | adr")
+        pp.add_argument("id", type=int, metavar="<id>",
+                        help="row id (from `mindkeep show`)")
 
     pe = sub.add_parser("export", help="dump a project to JSON")
     pe.add_argument("--project", default=None)
@@ -891,6 +957,10 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_show(data_dir, args)
         if args.cmd == "clear":
             return _cmd_clear(data_dir, args)
+        if args.cmd == "pin":
+            return _cmd_pin(data_dir, args, value=1)
+        if args.cmd == "unpin":
+            return _cmd_pin(data_dir, args, value=0)
         if args.cmd == "export":
             return _cmd_export(data_dir, args)
         if args.cmd == "import":

--- a/src/mindkeep/memory_api.py
+++ b/src/mindkeep/memory_api.py
@@ -340,11 +340,14 @@ class MemoryStore:
         source: str | None = None,
         *,
         force: bool = False,
+        pin: bool = False,
     ) -> int:
         """Persist a free-form fact; returns the new rowid.
 
         Pass ``force=True`` to bypass the post-redaction token cap
         (default 100, override via ``MINDKEEP_FACTS_TOKEN_CAP``).
+        ``pin=True`` marks the fact so it surfaces first in
+        :meth:`list_facts` (P1-8 / issue #13).
         """
         original = content
         content = self._run_filters("fact", "content", content)
@@ -364,20 +367,57 @@ class MemoryStore:
                 "source": source if source is not None else "agent",
                 "confidence": 1.0,
                 "token_estimate": token_estimate,
+                "pin": 1 if pin else 0,
                 "created_at": now,
                 "updated_at": now,
             },
         )
 
     def list_facts(
-        self, tag: str | None = None, limit: int = 100
+        self,
+        tag: str | None = None,
+        limit: int = 100,
+        *,
+        pinned_only: bool = False,
     ) -> list[dict[str, Any]]:
-        """Return facts (newest first), optionally filtered by tag."""
+        """Return facts ordered ``pin DESC, created_at DESC`` (P1-8).
+
+        * ``tag``         — keep only rows whose tag list contains ``tag``.
+        * ``limit``       — cap on returned rows.
+        * ``pinned_only`` — return only rows with ``pin = 1``.
+        """
         rows = self._storage.query("facts")
-        rows.sort(key=lambda r: r["updated_at"], reverse=True)
+        if pinned_only:
+            rows = [r for r in rows if int(r.get("pin") or 0) == 1]
+        rows.sort(
+            key=lambda r: (
+                int(r.get("pin") or 0),
+                r.get("created_at", ""),
+                int(r.get("id") or 0),
+            ),
+            reverse=True,
+        )
         if tag is not None:
             rows = [r for r in rows if tag in _tags_from_str(r["tags"])]
         return rows[: max(0, int(limit))]
+
+    def pin_fact(self, fact_id: int) -> None:
+        """Set ``pin = 1`` on the fact with id ``fact_id`` (P1-8)."""
+        self._set_pin("facts", int(fact_id), 1)
+
+    def unpin_fact(self, fact_id: int) -> None:
+        """Clear ``pin`` on the fact with id ``fact_id`` (P1-8)."""
+        self._set_pin("facts", int(fact_id), 0)
+
+    def _set_pin(self, table: str, row_id: int, value: int) -> None:
+        n = self._storage.update(
+            table,
+            where={"id": row_id},
+            values={"pin": value, "updated_at": _now_iso()},
+        )
+        if n == 0:
+            kind = "fact" if table == "facts" else "adr"
+            raise ValueError(f"{kind} id {row_id} not found")
 
     # ---- ADRs --------------------------------------------------------
 
@@ -391,11 +431,15 @@ class MemoryStore:
         tags: list[str] | None = None,
         *,
         force: bool = False,
+        pin: bool = False,
     ) -> int:
         """Record an Architecture Decision; returns the new rowid.
 
         The ADR ``number`` is auto-assigned as ``max(number) + 1``.
         ``rationale`` is stored in the schema's ``context`` column.
+
+        ``pin=True`` marks the ADR so it surfaces first in
+        :meth:`list_adrs` (P1-8 / issue #13).
 
         The read-max / insert sequence is serialised per-store with an
         ``RLock`` so concurrent callers never observe the same
@@ -435,19 +479,46 @@ class MemoryStore:
                     "supersedes": supersedes,
                     "tags": _tags_to_str(tags),
                     "token_estimate": token_estimate,
+                    "pin": 1 if pin else 0,
                     "created_at": now,
                     "updated_at": now,
                 },
             )
 
-    def list_adrs(self, status: str | None = None) -> list[dict[str, Any]]:
-        """Return ADRs sorted by ``number`` ascending."""
+    def list_adrs(
+        self,
+        status: str | None = None,
+        *,
+        pinned_only: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Return ADRs ordered ``pin DESC, created_at DESC`` (P1-8).
+
+        * ``status``      — equality-filter on the ADR status column.
+        * ``pinned_only`` — return only rows with ``pin = 1``.
+        """
         if status is not None:
             rows = self._storage.query("adrs", status=status)
         else:
             rows = self._storage.query("adrs")
-        rows.sort(key=lambda r: int(r["number"]))
+        if pinned_only:
+            rows = [r for r in rows if int(r.get("pin") or 0) == 1]
+        rows.sort(
+            key=lambda r: (
+                int(r.get("pin") or 0),
+                r.get("created_at", ""),
+                int(r.get("id") or 0),
+            ),
+            reverse=True,
+        )
         return rows
+
+    def pin_adr(self, adr_id: int) -> None:
+        """Set ``pin = 1`` on the ADR with id ``adr_id`` (P1-8)."""
+        self._set_pin("adrs", int(adr_id), 1)
+
+    def unpin_adr(self, adr_id: int) -> None:
+        """Clear ``pin`` on the ADR with id ``adr_id`` (P1-8)."""
+        self._set_pin("adrs", int(adr_id), 0)
 
     # ---- preferences (upsert, cross-project) -------------------------
 

--- a/src/mindkeep/storage.py
+++ b/src/mindkeep/storage.py
@@ -652,6 +652,39 @@ class Storage:
             self._conn.commit()
             return int(rowid)
 
+    def update(
+        self,
+        table: str,
+        *,
+        where: dict[str, Any],
+        values: dict[str, Any],
+    ) -> int:
+        """Equality-match UPDATE; returns number of rows affected.
+
+        Both ``where`` and ``values`` must be non-empty mappings. Column
+        names are validated against the cached schema whitelist.
+        """
+        self._check_table(table)
+        if not values:
+            raise ValueError("values must be a non-empty mapping")
+        if not where:
+            raise ValueError(
+                "update() requires at least one where filter; "
+                "refusing to overwrite a whole table"
+            )
+        self._check_columns(table, values.keys())
+        self._check_columns(table, where.keys())
+        set_clause = ", ".join(f"{k} = ?" for k in values)
+        where_clause = " AND ".join(f"{k} = ?" for k in where)
+        sql = f"UPDATE {table} SET {set_clause} WHERE {where_clause}"
+        with self._lock:
+            self._ensure_open()
+            cur = self._conn.execute(
+                sql, tuple(values.values()) + tuple(where.values())
+            )
+            self._conn.commit()
+            return cur.rowcount
+
     def query(self, table: str, **filters: Any) -> list[dict[str, Any]]:
         """Equality-match query; returns list of row dicts."""
         self._check_table(table)

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -108,12 +108,14 @@ def test_add_adr_auto_numbers_and_supersedes(store: MemoryStore) -> None:
     assert a2 > a1
 
     adrs = store.list_adrs()
-    assert [a["number"] for a in adrs] == [1, 2]
-    assert adrs[0]["title"] == "choose sqlite"
-    assert adrs[1]["supersedes"] == a1
+    # Default ordering is `pin DESC, created_at DESC` (P1-8); both ADRs
+    # are unpinned and a2 is newer, so it surfaces first.
+    assert [a["number"] for a in adrs] == [2, 1]
+    assert adrs[1]["title"] == "choose sqlite"
+    assert adrs[0]["supersedes"] == a1
     # rationale is persisted as context.
-    assert adrs[1]["context"] == "perf"
-    assert adrs[1]["decision"] == "enable WAL"
+    assert adrs[0]["context"] == "perf"
+    assert adrs[0]["decision"] == "enable WAL"
 
 
 def test_list_adrs_filter_by_status(store: MemoryStore) -> None:

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -1,0 +1,219 @@
+"""Tests for pin/unpin (issue #13, P1-8).
+
+Covers the Python API surface (``add_fact(pin=True)`` /
+``pin_fact`` / ``unpin_fact`` / ``pinned_only`` / default ordering) and
+the corresponding CLI subcommands (``mindkeep pin <kind> <id>``,
+``mindkeep show --pinned``).
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+from pathlib import Path
+
+import pytest
+
+from mindkeep.memory_api import MemoryStore
+
+
+# ──────────────────────────── fixtures ────────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> MemoryStore:
+    s = MemoryStore.open(cwd=tmp_path, data_dir=tmp_path)
+    yield s
+    s.close()
+
+
+# ──────────────────────────── facts: pin via add_fact ────────────────────────────
+
+
+def test_add_fact_pin_true_persists(store: MemoryStore) -> None:
+    fid = store.add_fact("pinned fact", pin=True)
+    rows = store.list_facts()
+    [row] = [r for r in rows if r["id"] == fid]
+    assert int(row["pin"]) == 1
+
+
+def test_add_fact_pin_false_default(store: MemoryStore) -> None:
+    fid = store.add_fact("unpinned")
+    [row] = [r for r in store.list_facts() if r["id"] == fid]
+    assert int(row["pin"]) == 0
+
+
+# ──────────────────────────── facts: pin/unpin round-trip ────────────────────────────
+
+
+def test_pin_unpin_fact_round_trip(store: MemoryStore) -> None:
+    fid = store.add_fact("subject")
+    assert int(store.list_facts()[0]["pin"]) == 0
+
+    store.pin_fact(fid)
+    [row] = [r for r in store.list_facts() if r["id"] == fid]
+    assert int(row["pin"]) == 1
+
+    store.unpin_fact(fid)
+    [row] = [r for r in store.list_facts() if r["id"] == fid]
+    assert int(row["pin"]) == 0
+
+
+def test_pin_fact_unknown_id_raises(store: MemoryStore) -> None:
+    with pytest.raises(ValueError, match="fact id 999 not found"):
+        store.pin_fact(999)
+    with pytest.raises(ValueError, match="fact id 999 not found"):
+        store.unpin_fact(999)
+
+
+# ──────────────────────────── facts: ordering & pinned_only ────────────────────────────
+
+
+def test_list_facts_pinned_first_default_ordering(store: MemoryStore) -> None:
+    # Insert 5 facts; pin two of them (the 2nd and 4th inserted).
+    ids = [store.add_fact(f"f{i}") for i in range(5)]
+    store.pin_fact(ids[1])
+    store.pin_fact(ids[3])
+
+    rows = store.list_facts()
+    # The two pinned rows must appear before any unpinned row.
+    pinned_positions = [i for i, r in enumerate(rows) if int(r["pin"]) == 1]
+    assert pinned_positions == [0, 1]
+    # And both pinned fact ids are present at the front.
+    assert {rows[0]["id"], rows[1]["id"]} == {ids[1], ids[3]}
+
+
+def test_list_facts_pinned_only_filters(store: MemoryStore) -> None:
+    a = store.add_fact("a")
+    store.add_fact("b")
+    c = store.add_fact("c", pin=True)
+    store.pin_fact(a)
+
+    pinned = store.list_facts(pinned_only=True)
+    assert {r["id"] for r in pinned} == {a, c}
+    assert all(int(r["pin"]) == 1 for r in pinned)
+
+
+# ──────────────────────────── ADRs: parity with facts ────────────────────────────
+
+
+def test_add_adr_pin_true_and_pin_adr(store: MemoryStore) -> None:
+    a1 = store.add_adr("t1", decision="d1", rationale="r1")
+    a2 = store.add_adr("t2", decision="d2", rationale="r2", pin=True)
+
+    rows = store.list_adrs()
+    by_id = {r["id"]: r for r in rows}
+    assert int(by_id[a1]["pin"]) == 0
+    assert int(by_id[a2]["pin"]) == 1
+    # Pinned a2 must appear before unpinned a1.
+    assert rows[0]["id"] == a2
+
+    store.unpin_adr(a2)
+    store.pin_adr(a1)
+    rows = store.list_adrs()
+    assert rows[0]["id"] == a1
+    assert int(rows[0]["pin"]) == 1
+
+
+def test_list_adrs_pinned_only(store: MemoryStore) -> None:
+    store.add_adr("t1", decision="d1", rationale="r1")
+    a2 = store.add_adr("t2", decision="d2", rationale="r2", pin=True)
+    pinned = store.list_adrs(pinned_only=True)
+    assert [r["id"] for r in pinned] == [a2]
+
+
+def test_pin_adr_unknown_id_raises(store: MemoryStore) -> None:
+    with pytest.raises(ValueError, match="adr id 4242 not found"):
+        store.pin_adr(4242)
+
+
+# ──────────────────────────── CLI ────────────────────────────
+
+
+def _run_main(data_dir: Path, cwd: Path, *args: str) -> tuple[int, str, str]:
+    """Invoke mindkeep CLI in-process, with data_dir patched in."""
+    from mindkeep import cli as cli_mod
+
+    real_default = cli_mod.default_data_dir
+    cli_mod.default_data_dir = lambda: data_dir  # type: ignore[assignment]
+    saved_cwd = os.getcwd()
+    os.chdir(cwd)
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            try:
+                code = cli_mod.main(list(args))
+            except SystemExit as exc:
+                code = int(exc.code or 0)
+    finally:
+        cli_mod.default_data_dir = real_default  # type: ignore[assignment]
+        os.chdir(saved_cwd)
+    return code, out.getvalue(), err.getvalue()
+
+
+def test_cli_pin_unpin_fact(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+
+    # Seed a fact through the API at the same data_dir + cwd so the CLI
+    # resolves to the same project.
+    s = MemoryStore.open(cwd=cwd, data_dir=data_dir)
+    fid = s.add_fact("subject")
+    s.close()
+
+    code, out, err = _run_main(data_dir, cwd, "pin", "fact", str(fid))
+    assert code == 0, (out, err)
+    assert "pinned fact" in out
+
+    # show --pinned should now include the fact.
+    code, out, err = _run_main(
+        data_dir, cwd, "show", "--kind", "facts", "--pinned",
+    )
+    assert code == 0, (out, err)
+    assert "subject" in out
+
+    # unpin → show --pinned should be empty (no rows).
+    code, out, err = _run_main(data_dir, cwd, "unpin", "fact", str(fid))
+    assert code == 0, (out, err)
+    code, out, err = _run_main(
+        data_dir, cwd, "show", "--kind", "facts", "--pinned",
+    )
+    assert code == 0
+    assert "(no rows)" in out
+
+
+def test_cli_pin_unknown_id_exits_2(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+
+    # Materialise a project DB so resolution succeeds, then ask to pin
+    # a non-existent id.
+    MemoryStore.open(cwd=cwd, data_dir=data_dir).close()
+
+    code, out, err = _run_main(data_dir, cwd, "pin", "fact", "999")
+    assert code == 2, (out, err)
+    assert "not found" in err
+
+
+def test_cli_show_pinned_only_filters(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+
+    s = MemoryStore.open(cwd=cwd, data_dir=data_dir)
+    s.add_fact("alpha")
+    pinned_id = s.add_fact("bravo", pin=True)
+    s.close()
+
+    code, out, err = _run_main(
+        data_dir, cwd, "show", "--kind", "facts", "--pinned",
+    )
+    assert code == 0, (out, err)
+    assert "bravo" in out
+    assert "alpha" not in out
+    _ = pinned_id  # silence unused


### PR DESCRIPTION
Closes #13

Wires the schema v3 `pin` column through the Python API and CLI.
Design ref: `docs/DESIGN-v0.3.0.md` (P1-8).

## API additions
- `MemoryStore.add_fact(content, ..., *, pin=False)` — keyword-only `pin` flag.
- `MemoryStore.add_adr(title, decision, rationale, ..., *, pin=False)`.
- `MemoryStore.pin_fact(id)` / `unpin_fact(id)` / `pin_adr(id)` / `unpin_adr(id)` — raise `ValueError` on unknown id.
- `MemoryStore.list_facts(..., *, pinned_only=False)` and `list_adrs(..., *, pinned_only=False)`.
- New default ordering for both: `pin DESC, created_at DESC, id DESC` so pinned rows surface first; `id` tie-breaker keeps order deterministic when two inserts share a second-precision timestamp.
- `Storage.update(table, *, where, values)` — minimal equality UPDATE used by the pin helpers (column-whitelist enforced like `insert`/`query`/`delete`).

## CLI additions
- `mindkeep pin <fact|adr> <id>`  / `mindkeep unpin <fact|adr> <id>`: exit `0` on success, exit `2` (with `error: ... not found`) on unknown id.
- `mindkeep show --kind facts --pinned` / `--kind adrs --pinned` filter to pinned rows; the `show` table now includes a `pin` column (`*` for pinned).

Examples:
`
$ mindkeep pin fact 12
pinned fact 12 in <project>
$ mindkeep show --kind facts --pinned
$ mindkeep unpin adr 3
`

## Tests
- New `tests/test_pin.py` (12 cases): pin via `add_fact` / `add_adr`, round-trip `pin_fact`/`unpin_fact`, `ValueError` on unknown id, `pinned_only` filter, mixed-ordering scenario (5 facts / 2 pinned), CLI `pin`/`unpin` exit codes, `show --pinned` filter.
- Updated `test_memory_api.test_add_adr_auto_numbers_and_supersedes` for the new `pin DESC, created_at DESC` default — both ADRs unpinned, so `a2` (newer) now sorts first.

Full suite: 176 passed locally.

## Parallel siblings (per task brief)
- #7 session budget — no overlap.
- #11 stats — read-only consumer of the same `pin` column; this PR only adds writes / extra ordering, so stats reads stay correct.
- #12 write guard — both branches touch `add_fact` / `add_adr` signatures; this PR only **appends** a keyword-only `pin` parameter, so the merges should be straightforward.
