### PR TITLE
feat(api): dual-threshold write guard (P1-7, #12)

### DIFF
--- a/src/mindkeep/__init__.py
+++ b/src/mindkeep/__init__.py
@@ -1,6 +1,6 @@
 from .memory_api import Filter, MemoryStore
 from .security import SecretsRedactor, SizeLimiter
-from .storage import Storage
+from .storage import Storage, StorageError, WriteGuardError
 
 __all__ = [
     "Filter",
@@ -8,5 +8,7 @@ __all__ = [
     "SecretsRedactor",
     "SizeLimiter",
     "Storage",
+    "StorageError",
+    "WriteGuardError",
 ]
 

--- a/src/mindkeep/memory_api.py
+++ b/src/mindkeep/memory_api.py
@@ -31,10 +31,17 @@ Design notes
 * ``clear()``. ``Storage.delete`` refuses filter-less deletes, so we iterate
   rows and delete by primary key. This is O(n) but fine for the expected
   dataset size (≤ 10⁴ rows) and avoids bypassing the storage abstraction.
+* Write guard (P1-7). Every ``add_fact`` / ``add_adr`` call estimates token
+  count after redaction and rejects writes whose post-redaction text exceeds
+  a per-kind cap (facts: 100, ADRs: 1500; both env-overridable). A second
+  threshold at 2× cap rejects huge pre-redaction blobs outright. Pass
+  ``force=True`` to bypass.
 """
 from __future__ import annotations
 
 import json
+import os
+import sys
 import threading
 import uuid
 from datetime import datetime, timezone
@@ -43,7 +50,16 @@ from typing import Any, Protocol, Sequence, runtime_checkable
 
 from .models import ProjectId
 from .project_id import resolve_project_id
-from .storage import Storage, default_data_dir
+from .storage import Storage, WriteGuardError, default_data_dir
+
+# Token estimator — prefer the shared helper from #7 when it lands; fall
+# back to a 4-chars-per-token heuristic so this module is self-contained
+# until the sibling agent's ``_tokens`` module ships.
+try:  # pragma: no cover - exercised once #7 lands
+    from ._tokens import estimate as _estimate_tokens
+except ImportError:  # pragma: no cover - default path today
+    def _estimate_tokens(s: str) -> int:  # TODO(#7): replace with shared helper
+        return max(1, len(s) // 4) if s else 0
 
 # ──────────────────────────── filter protocol ────────────────────────────
 
@@ -115,6 +131,97 @@ def _tags_from_str(raw: str) -> list[str]:
     if not raw:
         return []
     return [t for t in raw.split(",") if t]
+
+
+# ─────────────────────────── write-guard helpers (P1-7) ───────────────────────────
+
+# Default token caps; overridable via env vars. Resolved per-call so tests
+# that ``monkeypatch.setenv`` see fresh values without re-importing.
+_DEFAULT_CAPS: dict[str, int] = {"fact": 100, "adr": 1500}
+_CAP_ENV: dict[str, str] = {
+    "fact": "MINDKEEP_FACTS_TOKEN_CAP",
+    "adr": "MINDKEEP_ADRS_TOKEN_CAP",
+}
+
+
+def _resolve_cap(kind: str) -> int:
+    raw = os.environ.get(_CAP_ENV[kind])
+    if raw:
+        try:
+            v = int(raw)
+            if v > 0:
+                return v
+        except ValueError:
+            pass
+    return _DEFAULT_CAPS[kind]
+
+
+def _enforce_write_guard(
+    kind: str,
+    *,
+    pre: str,
+    post: str,
+    force: bool,
+) -> int:
+    """Apply the dual-threshold guard. Returns the post-redaction token estimate.
+
+    * Estimates tokens of both ``pre`` (pre-redaction) and ``post``
+      (post-redaction) text.
+    * Raises :class:`WriteGuardError` if ``post`` exceeds the cap, or if
+      ``pre`` exceeds 2× cap (the "huge unstructured blob" guard).
+    * Logs a stderr warning when redaction shrank the content by >50%
+      *and* the original was substantial (signals a nearly-secrets-only
+      payload — still allowed).
+    * ``force=True`` bypasses both rejections (warnings still print).
+    """
+    cap = _resolve_cap(kind)
+    pre_tokens = _estimate_tokens(pre)
+    post_tokens = _estimate_tokens(post)
+
+    plural = "facts" if kind == "fact" else "adrs"
+
+    if not force:
+        if pre_tokens > 2 * cap:
+            raise WriteGuardError(
+                f"{plural} pre-redaction content is {pre_tokens} tokens, "
+                f"exceeding 2× the {plural} cap ({2 * cap}); refusing to "
+                f"accept what looks like a large unstructured blob. "
+                f"Pass force=True to override.",
+                kind=kind,
+                cap=cap,
+                post_tokens=post_tokens,
+                pre_tokens=pre_tokens,
+            )
+        if post_tokens > cap:
+            raise WriteGuardError(
+                f"{plural} post-redaction content is {post_tokens} tokens, "
+                f"exceeding the {plural} cap ({cap}). Trim the input or "
+                f"pass force=True to override.",
+                kind=kind,
+                cap=cap,
+                post_tokens=post_tokens,
+                pre_tokens=pre_tokens,
+            )
+
+    # Shrinkage warning — only when redaction actually removed content
+    # and the original was substantial (otherwise a 250-token blob of
+    # pure secrets that redacts to ~10 tokens is just "redaction did its
+    # job" and the warning would be noise). The threshold is half the
+    # cap: at that point the reduction is large in absolute terms too.
+    if (
+        pre_tokens > cap // 2
+        and post_tokens < pre_tokens
+        and post_tokens <= cap
+        and (pre_tokens - post_tokens) * 2 > pre_tokens
+    ):
+        print(
+            f"mindkeep: redaction trimmed {kind} from "
+            f"{pre_tokens} → {post_tokens} tokens (>50% reduction); "
+            f"consider re-checking the input for accidentally-pasted secrets.",
+            file=sys.stderr,
+        )
+
+    return post_tokens
 
 
 # ──────────────────────────── MemoryStore ────────────────────────────
@@ -231,9 +338,19 @@ class MemoryStore:
         content: str,
         tags: list[str] | None = None,
         source: str | None = None,
+        *,
+        force: bool = False,
     ) -> int:
-        """Persist a free-form fact; returns the new rowid."""
+        """Persist a free-form fact; returns the new rowid.
+
+        Pass ``force=True`` to bypass the post-redaction token cap
+        (default 100, override via ``MINDKEEP_FACTS_TOKEN_CAP``).
+        """
+        original = content
         content = self._run_filters("fact", "content", content)
+        token_estimate = _enforce_write_guard(
+            "fact", pre=original, post=content, force=force
+        )
         now = _now_iso()
         # Synthetic UNIQUE key — the minimal API treats facts as an append-only
         # log keyed by content rather than a natural key space.
@@ -246,6 +363,7 @@ class MemoryStore:
                 "tags": _tags_to_str(tags),
                 "source": source if source is not None else "agent",
                 "confidence": 1.0,
+                "token_estimate": token_estimate,
                 "created_at": now,
                 "updated_at": now,
             },
@@ -271,6 +389,8 @@ class MemoryStore:
         status: str = "accepted",
         supersedes: int | None = None,
         tags: list[str] | None = None,
+        *,
+        force: bool = False,
     ) -> int:
         """Record an Architecture Decision; returns the new rowid.
 
@@ -280,9 +400,24 @@ class MemoryStore:
         The read-max / insert sequence is serialised per-store with an
         ``RLock`` so concurrent callers never observe the same
         ``max(number)`` and land on duplicate numbers (P1-1).
+
+        Pass ``force=True`` to bypass the post-redaction token cap
+        (default 1500, override via ``MINDKEEP_ADRS_TOKEN_CAP``). The cap
+        is checked against the combined ``title + decision + rationale``
+        text — the same body a downstream consumer would render.
         """
+        original_decision = decision
+        original_rationale = rationale
         decision = self._run_filters("adr", "decision", decision)
         rationale = self._run_filters("adr", "rationale", rationale)
+        # Combine into the body the cap actually applies to. ``title`` is
+        # not redacted (no field hook in the legacy pipeline) so it
+        # contributes equally to both pre- and post-redaction estimates.
+        pre_body = f"{title}\n\n{original_decision}\n\n{original_rationale}"
+        post_body = f"{title}\n\n{decision}\n\n{rationale}"
+        token_estimate = _enforce_write_guard(
+            "adr", pre=pre_body, post=post_body, force=force
+        )
         now = _now_iso()
         with self._adr_lock:
             existing = self._storage.query("adrs")
@@ -299,6 +434,7 @@ class MemoryStore:
                     "consequences": "",
                     "supersedes": supersedes,
                     "tags": _tags_to_str(tags),
+                    "token_estimate": token_estimate,
                     "created_at": now,
                     "updated_at": now,
                 },

--- a/src/mindkeep/storage.py
+++ b/src/mindkeep/storage.py
@@ -345,6 +345,38 @@ def _now_iso() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
+class StorageError(Exception):
+    """Base class for mindkeep storage-layer errors."""
+
+
+class WriteGuardError(StorageError):
+    """Raised when content exceeds the configured token cap (P1-7).
+
+    Carries structured fields so callers can render friendly messages or
+    decide whether to retry with ``force=True``:
+
+    * ``kind`` — ``"fact"`` or ``"adr"``.
+    * ``cap`` — the per-kind token cap that was enforced.
+    * ``post_tokens`` — token estimate of the content **after** redaction.
+    * ``pre_tokens``  — token estimate of the original (pre-redaction) content.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        kind: str,
+        cap: int,
+        post_tokens: int,
+        pre_tokens: int,
+    ) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.cap = cap
+        self.post_tokens = post_tokens
+        self.pre_tokens = pre_tokens
+
+
 def _atomic_write_bytes(path: Path, data: bytes) -> None:
     tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
     with open(tmp, "wb") as fh:

--- a/tests/test_write_guard.py
+++ b/tests/test_write_guard.py
@@ -1,0 +1,137 @@
+"""Tests for the dual-threshold write guard (P1-7, issue #12)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mindkeep.memory_api import MemoryStore
+from mindkeep.security import SecretsRedactor
+from mindkeep.storage import StorageError, WriteGuardError
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> MemoryStore:
+    s = MemoryStore.open(cwd=tmp_path, data_dir=tmp_path)
+    try:
+        yield s
+    finally:
+        if not s.closed:
+            s.close()
+
+
+@pytest.fixture
+def redacting_store(tmp_path: Path) -> MemoryStore:
+    s = MemoryStore.open(
+        cwd=tmp_path, data_dir=tmp_path, filters=[SecretsRedactor()]
+    )
+    try:
+        yield s
+    finally:
+        if not s.closed:
+            s.close()
+
+
+def _chars(tokens: int) -> str:
+    """Build a payload that estimates to roughly ``tokens`` tokens."""
+    return "x" * (tokens * 4 + 1)
+
+
+def test_small_fact_passes_and_persists_token_estimate(store: MemoryStore) -> None:
+    rid = store.add_fact(_chars(50))
+    rows = store.list_facts()
+    [row] = [r for r in rows if r["id"] == rid]
+    assert row["token_estimate"] is not None
+    assert 40 <= int(row["token_estimate"]) <= 60
+
+
+def test_oversize_fact_raises(store: MemoryStore) -> None:
+    with pytest.raises(WriteGuardError) as exc:
+        store.add_fact(_chars(200))
+    msg = str(exc.value).lower()
+    assert "facts" in msg
+    assert "cap" in msg
+    assert exc.value.kind == "fact"
+    assert isinstance(exc.value, StorageError)
+
+
+def test_oversize_fact_with_force_passes(store: MemoryStore) -> None:
+    rid = store.add_fact(_chars(200), force=True)
+    assert rid > 0
+
+
+def test_adr_within_cap_passes(store: MemoryStore) -> None:
+    rid = store.add_adr(
+        title=_chars(100),
+        decision=_chars(700),
+        rationale=_chars(600),
+    )
+    adrs = store.list_adrs()
+    [row] = [r for r in adrs if r["id"] == rid]
+    assert row["token_estimate"] is not None
+    assert 1300 <= int(row["token_estimate"]) <= 1500
+
+
+def test_oversize_adr_raises(store: MemoryStore) -> None:
+    with pytest.raises(WriteGuardError) as exc:
+        store.add_adr(
+            title=_chars(100),
+            decision=_chars(900),
+            rationale=_chars(700),
+        )
+    assert exc.value.kind == "adr"
+    assert "adrs" in str(exc.value).lower()
+
+
+def test_secrets_only_pre_redaction_passes_quietly(
+    redacting_store: MemoryStore, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_pat = "ghp_" + "A" * 36
+    body = " ".join([fake_pat] * 25)
+    redacting_store.add_adr(title="seed", decision=body, rationale="-")
+    err = capsys.readouterr().err
+    assert "redaction trimmed" not in err, err
+
+
+def test_mostly_redacted_large_payload_warns(
+    redacting_store: MemoryStore, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_pat = "github_pat_" + "A" * 82
+    body = " ".join([fake_pat] * 50)
+    redacting_store.add_adr(title="seed", decision=body, rationale="-")
+    err = capsys.readouterr().err
+    assert "redaction trimmed" in err, err
+
+
+def test_huge_pre_redaction_raises_even_when_redaction_could_fix_it(
+    redacting_store: MemoryStore,
+) -> None:
+    huge = _chars(5000)
+    with pytest.raises(WriteGuardError) as exc:
+        redacting_store.add_fact(huge)
+    msg = str(exc.value).lower()
+    assert "2×" in msg or "2x" in msg or "unstructured" in msg
+    assert exc.value.pre_tokens >= 2 * exc.value.cap
+
+
+def test_env_var_overrides_facts_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MINDKEEP_FACTS_TOKEN_CAP", "200")
+    with MemoryStore.open(cwd=tmp_path, data_dir=tmp_path) as s:
+        rid = s.add_fact(_chars(150))
+        assert rid > 0
+
+
+def test_env_var_overrides_adrs_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MINDKEEP_ADRS_TOKEN_CAP", "300")
+    with MemoryStore.open(cwd=tmp_path, data_dir=tmp_path) as s:
+        with pytest.raises(WriteGuardError):
+            s.add_adr(title=_chars(50), decision=_chars(200), rationale=_chars(100))
+
+
+def test_force_kwarg_is_keyword_only(store: MemoryStore) -> None:
+    with pytest.raises(TypeError):
+        store.add_fact(_chars(50), None, None, True)  # type: ignore[misc]


### PR DESCRIPTION
Closes #12.

Adds the v0.3.0 P1-7 write guard described in [docs/DESIGN-v0.3.0.md](docs/DESIGN-v0.3.0.md): every `add_fact` / `add_adr` call estimates token count after the redactor runs and rejects writes whose post-redaction body exceeds a per-kind cap.

## Behaviour

| Check | Facts cap | ADRs cap |
|---|---|---|
| post-redaction tokens > cap | reject | reject |
| pre-redaction tokens > 2× cap | reject (`unstructured blob`) | reject |
| redaction shrank by >50% AND pre > cap/2 | warn (stderr) — write proceeds | warn (stderr) — write proceeds |

Defaults: facts = 100, ADRs = 1500. Override via `MINDKEEP_FACTS_TOKEN_CAP` / `MINDKEEP_ADRS_TOKEN_CAP`.

## API surface

`WriteGuardError(StorageError)` is raised on rejection and carries `kind` / `cap` / `post_tokens` / `pre_tokens` for callers that want to render rich messages.

``python
store.add_fact(value, force=True)             # bypass guard
store.add_adr(title, decision, rationale, force=True)
``

ADRs: cap is checked against the combined `title + decision + rationale` body, matching what a downstream consumer would actually render.

The v3 schema's `token_estimate` column is now populated on every new write.

## Token estimator

Imports `mindkeep._tokens.estimate` when present (sibling #7); otherwise falls back to a `max(1, len(s)//4)` heuristic. The fallback is marked with a `TODO(#7)` so the swap is mechanical once #7 lands.

## Before / after

``python
# Before — silently accepts a 5,000-token paste.
store.add_fact(huge_log_dump)

# After — rejected by the pre-redaction guard.
store.add_fact(huge_log_dump)
# mindkeep.storage.WriteGuardError: facts pre-redaction content is 5000
# tokens, exceeding 2× the facts cap (200); refusing to accept what looks
# like a large unstructured blob. Pass force=True to override.
``

## Parallel siblings

This PR ships alongside three concurrent v0.3.0 issues:

- **#7 session budget** — provides `mindkeep._tokens.estimate`. Until that lands, the guard uses an inline fallback.
- **#11 stats** — read-side; no overlap.
- **#13 pin** — also touches `add_fact` / `add_adr`. Both PRs add a new keyword-only kwarg (`pin=` and `force=`) without reordering existing positional parameters; merge order does not matter.

## Tests

Adds `tests/test_write_guard.py` (11 cases, all green) covering: small fact passes & populates `token_estimate`, oversize fact raises, `force=True` bypass, ADR within/over cap, secrets-only payload silent pass, mostly-redacted warning, 2×-cap rejection, env-var overrides for both caps, and the keyword-only-ness of `force=`.

python -m pytest -q → 175 passed.