### PR TITLE
feat(cli): --top K / --budget N for show (P0-3, #8)

### DIFF
--- a/src/mindkeep/cli.py
+++ b/src/mindkeep/cli.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 from . import _session
+from ._tokens import estimate as _estimate_tokens
 from .memory_api import MemoryStore
 from .models import ProjectId
 from .project_id import resolve_project_id
@@ -254,11 +255,35 @@ def _tags_list(raw: str) -> list[str]:
     return [t for t in (raw or "").split(",") if t]
 
 
+class _BudgetTracker:
+    """Track remaining token budget across rendered rows for ``mindkeep show``.
+
+    ``remaining is None`` means unlimited (no ``--budget`` flag was passed).
+    """
+
+    __slots__ = ("remaining",)
+
+    def __init__(self, total: int | None) -> None:
+        self.remaining: int | None = total
+
+    def try_spend(self, text: str) -> bool:
+        """Deduct tokens for *text* if it fits. Return True if accepted."""
+        if self.remaining is None:
+            return True
+        cost = _estimate_tokens(text)
+        if cost > self.remaining:
+            return False
+        self.remaining -= cost
+        return True
+
+
 def _show_kind(
     storage: Storage, kind: str, tag: str | None, limit: int,
     pref_storage: Storage | None = None,
     full: bool = False,
     pinned_only: bool = False,
+    top: int | None = None,
+    budget: _BudgetTracker | None = None,
 ) -> None:
     # In ``--full`` mode, large free-text columns render raw (newlines
     # preserved, no width cap). Alignment is sacrificed; see PRD-ux-polish.
@@ -353,11 +378,25 @@ def _show_kind(
             for r in rows
         ]
 
+    if top is not None:
+        data = data[: max(0, top)]
+
     print(f"== {kind} ==")
     if not data:
         print("(no rows)")
     else:
-        print(_render_table(headers, data))
+        rendered = _render_table(headers, data).split("\n")
+        header_line, sep_line, *row_lines = rendered
+        kept: list[str] = []
+        for line in row_lines:
+            if budget is not None:
+                if not budget.try_spend(line):
+                    break
+            kept.append(line)
+        if not kept:
+            print("(no rows)")
+        else:
+            print("\n".join([header_line, sep_line, *kept]))
     print()
 
 
@@ -370,13 +409,17 @@ def _cmd_show(data_dir: Path, args: argparse.Namespace) -> int:
     ps = _open_pref_storage(data_dir)
     buf = io.StringIO()
     real_stdout = sys.stdout
+    top = getattr(args, "top", None)
+    budget_total = getattr(args, "budget", None)
+    tracker = _BudgetTracker(budget_total) if budget_total is not None else None
     try:
         sys.stdout = buf
         print(f"project: {ph}")
         for kind in kinds:
             _show_kind(s, kind, args.tag, args.limit,
                        pref_storage=ps, full=full,
-                       pinned_only=bool(getattr(args, "pinned", False)))
+                       pinned_only=bool(getattr(args, "pinned", False)),
+                       top=top, budget=tracker)
     finally:
         sys.stdout = real_stdout
         s.close()
@@ -962,6 +1005,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ps.add_argument("--tag", default=None)
     ps.add_argument("--limit", type=int, default=20)
+    ps.add_argument(
+        "--top", type=int, default=None,
+        help="cap rows per kind (in addition to --limit); default unlimited (P0-3)",
+    )
+    ps.add_argument(
+        "--budget", type=int, default=None,
+        help="cap cumulative rendered token count across all rows shown; "
+             "default unlimited (P0-3)",
+    )
     ps.add_argument(
         "--pinned", action="store_true",
         help="only show pinned facts/ADRs (P1-8)",

--- a/tests/test_show_top_budget.py
+++ b/tests/test_show_top_budget.py
@@ -1,0 +1,192 @@
+"""Tests for ``mindkeep show --top K`` and ``--budget N`` (issue #8, P0-3)."""
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+from pathlib import Path
+
+from mindkeep._tokens import estimate as _estimate_tokens
+from mindkeep.memory_api import MemoryStore
+
+
+# ──────────────────────────── helpers ────────────────────────────
+
+
+def _run_main(data_dir: Path, cwd: Path, *args: str) -> tuple[int, str, str]:
+    """Invoke the mindkeep CLI in-process, with ``data_dir`` patched in."""
+    from mindkeep import cli as cli_mod
+
+    real_default = cli_mod.default_data_dir
+    cli_mod.default_data_dir = lambda: data_dir  # type: ignore[assignment]
+    saved_cwd = os.getcwd()
+    os.chdir(cwd)
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            try:
+                code = cli_mod.main(list(args))
+            except SystemExit as exc:
+                code = int(exc.code or 0)
+    finally:
+        cli_mod.default_data_dir = real_default  # type: ignore[assignment]
+        os.chdir(saved_cwd)
+    return code, out.getvalue(), err.getvalue()
+
+
+def _seed(cwd: Path, data_dir: Path,
+          n_facts: int = 5, n_adrs: int = 5,
+          pinned_fact: bool = False) -> None:
+    s = MemoryStore.open(cwd=cwd, data_dir=data_dir)
+    try:
+        for i in range(n_facts):
+            s.add_fact(f"fact-{i:02d}-value-content")
+        if pinned_fact:
+            s.add_fact("PINNED-fact-value", pin=True)
+        for i in range(n_adrs):
+            s.add_adr(
+                title=f"adr-{i:02d}-title",
+                decision=f"adr-{i:02d}-decision",
+                rationale=f"adr-{i:02d}-rationale",
+            )
+    finally:
+        s.close()
+
+
+def _data_rows(out: str, kind: str) -> list[str]:
+    """Return the data row lines under ``== {kind} ==`` (excluding header/sep)."""
+    lines = out.splitlines()
+    try:
+        start = lines.index(f"== {kind} ==")
+    except ValueError:
+        return []
+    rows: list[str] = []
+    # Skip header and separator (two lines after the section header), then collect
+    # until the next blank line.
+    if start + 1 < len(lines) and lines[start + 1] == "(no rows)":
+        return []
+    body = lines[start + 3:]
+    for line in body:
+        if line == "" or line.startswith("== "):
+            break
+        rows.append(line)
+    return rows
+
+
+# ──────────────────────────── tests ────────────────────────────
+
+
+def test_top_caps_rows_per_kind(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"; data_dir.mkdir()
+    cwd = tmp_path / "proj"; cwd.mkdir()
+    _seed(cwd, data_dir, n_facts=5, n_adrs=5)
+
+    code, out, err = _run_main(
+        data_dir, cwd, "show", "--kind", "all", "--top", "2",
+    )
+    assert code == 0, (out, err)
+    assert len(_data_rows(out, "facts")) <= 2
+    assert len(_data_rows(out, "adrs")) <= 2
+
+
+def test_top_zero_yields_no_rows(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"; data_dir.mkdir()
+    cwd = tmp_path / "proj"; cwd.mkdir()
+    _seed(cwd, data_dir, n_facts=3, n_adrs=3)
+
+    code, out, err = _run_main(
+        data_dir, cwd, "show", "--kind", "all", "--top", "0",
+    )
+    assert code == 0, (out, err)
+    assert _data_rows(out, "facts") == []
+    assert _data_rows(out, "adrs") == []
+    # Section header still printed with "(no rows)" placeholder.
+    assert "== facts ==" in out
+    assert "(no rows)" in out
+
+
+def test_budget_stops_after_rendered_tokens_exceed(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"; data_dir.mkdir()
+    cwd = tmp_path / "proj"; cwd.mkdir()
+    _seed(cwd, data_dir, n_facts=10, n_adrs=10)
+
+    code, out, err = _run_main(
+        data_dir, cwd, "show", "--kind", "all", "--budget", "50",
+    )
+    assert code == 0, (out, err)
+    fact_rows = _data_rows(out, "facts")
+    adr_rows = _data_rows(out, "adrs")
+    pref_rows = _data_rows(out, "preferences")
+    sess_rows = _data_rows(out, "sessions")
+    total_tokens = sum(
+        _estimate_tokens(line)
+        for line in fact_rows + adr_rows + pref_rows + sess_rows
+    )
+    assert total_tokens <= 50, (total_tokens, out)
+
+
+def test_budget_too_small_yields_zero_rows_no_crash(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"; data_dir.mkdir()
+    cwd = tmp_path / "proj"; cwd.mkdir()
+    _seed(cwd, data_dir, n_facts=3, n_adrs=3)
+
+    code, out, err = _run_main(
+        data_dir, cwd, "show", "--kind", "facts", "--budget", "1",
+    )
+    assert code == 0, (out, err)
+    assert _data_rows(out, "facts") == []
+    assert "(no rows)" in out
+
+
+def test_top_and_budget_combined_respect_tighter(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"; data_dir.mkdir()
+    cwd = tmp_path / "proj"; cwd.mkdir()
+    _seed(cwd, data_dir, n_facts=10, n_adrs=10)
+
+    # Top would allow 5 per kind, but a tight budget should clip earlier.
+    code, out, err = _run_main(
+        data_dir, cwd, "show", "--kind", "all",
+        "--top", "5", "--budget", "30",
+    )
+    assert code == 0, (out, err)
+    assert len(_data_rows(out, "facts")) <= 5
+    assert len(_data_rows(out, "adrs")) <= 5
+    total_tokens = sum(
+        _estimate_tokens(line)
+        for kind in ("facts", "adrs", "preferences", "sessions")
+        for line in _data_rows(out, kind)
+    )
+    assert total_tokens <= 30
+
+
+def test_pinned_rows_appear_first_under_top(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"; data_dir.mkdir()
+    cwd = tmp_path / "proj"; cwd.mkdir()
+    # 5 unpinned facts plus one pinned: pinned row must surface within --top 1.
+    _seed(cwd, data_dir, n_facts=5, n_adrs=0, pinned_fact=True)
+
+    code, out, err = _run_main(
+        data_dir, cwd, "show", "--kind", "facts", "--top", "1",
+    )
+    assert code == 0, (out, err)
+    rows = _data_rows(out, "facts")
+    assert len(rows) == 1
+    assert "PINNED-fact-value" in rows[0]
+    # The asterisk pin marker should be present in the surviving row.
+    assert " * " in rows[0] or rows[0].startswith("* ") or "| *" in rows[0]
+
+
+def test_default_unchanged_no_flags(tmp_path: Path) -> None:
+    """Without --top / --budget, output for a small project matches a stable shape."""
+    data_dir = tmp_path / "data"; data_dir.mkdir()
+    cwd = tmp_path / "proj"; cwd.mkdir()
+    _seed(cwd, data_dir, n_facts=3, n_adrs=2)
+
+    code, out, err = _run_main(data_dir, cwd, "show", "--kind", "all")
+    assert code == 0, (out, err)
+    # All 3 facts and 2 adrs are present (well under the default --limit=20).
+    assert len(_data_rows(out, "facts")) == 3
+    assert len(_data_rows(out, "adrs")) == 2
+    # Section headers exist.
+    for kind in ("facts", "adrs", "preferences", "sessions"):
+        assert f"== {kind} ==" in out


### PR DESCRIPTION
Closes #8
Milestone: https://github.com/AllenS0104/mindkeep/milestone/3 (v0.3.0)

## Summary

Adds two new flags to `mindkeep show` so callers can cap output by row count or by *rendered token count*:

- `--top K` — cap rows per kind (in addition to `--limit`); default unlimited.
- `--budget N` — cap cumulative rendered token count across all rows shown, using `mindkeep._tokens.estimate` on each rendered row line. Stops emitting once the next row would exceed the remaining budget.

Both flags are combinable; the tighter constraint wins. Default ordering (pinned-first via P1-8) is preserved, so pinned rows surface before unpinned ones under either cap. The session-budget buffering added in P0-2 is unchanged.

## Behavior

- Token counting uses the *rendered* row string (post-formatting / truncation) so tags / timestamps / numeric columns all count.
- `--top 0` → 0 rows of that kind, exit 0.
- `--budget` too small for even one row → 0 rows, exit 0, no crash.
- Default behavior with neither flag is unchanged.

## Tests

- New `tests/test_show_top_budget.py` (7 cases): top cap, top=0, budget cap, budget too small, top+budget combined, pinned-first under top, default-unchanged baseline.
- Full suite: **217 passed** (was ~210 baseline).