### PR TITLE
feat(api,cli): mindkeep recall <query> (FTS5 + bm25) (P0-4, #9)

### DIFF
--- a/src/mindkeep/cli.py
+++ b/src/mindkeep/cli.py
@@ -848,6 +848,68 @@ def _cmd_upgrade(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_recall(data_dir: Path, args: argparse.Namespace) -> int:
+    """Full-text search across facts and ADRs (P0-4, #9).
+
+    Honors the session budget via the same StringIO-buffering pattern as
+    ``_cmd_show``: render the entire output first, then feed it through
+    ``_session.emit_or_suppress`` so a single call cannot quietly half-print.
+    """
+    import io
+
+    from .memory_api import MemoryStore
+
+    raw_query = args.query or ""
+    if not raw_query.strip():
+        print(
+            "error: recall requires a non-empty query",
+            file=sys.stderr,
+        )
+        return 2
+
+    ph = _resolve_project_hash(data_dir, args.project)
+    pid = ProjectId(id=ph, source="cli", origin="recall", display_name="")
+    storage = _open_storage(data_dir, ph)
+    pref_storage = _open_pref_storage(data_dir)
+    store = MemoryStore(pid, storage, pref_storage=pref_storage)
+    try:
+        hits = store.recall(raw_query, top=args.top, kind=args.kind)
+    finally:
+        store.close()
+
+    if getattr(args, "json", False):
+        payload = [h.to_dict() for h in hits]
+        rendered = json.dumps(payload, indent=2, ensure_ascii=False)
+        _session.emit_or_suppress(rendered)
+        return 0
+
+    if not hits:
+        _session.emit_or_suppress("No results.")
+        return 0
+
+    buf = io.StringIO()
+    buf.write(
+        f"recall: {len(hits)} hit(s) for {raw_query!r} "
+        f"(lower bm25 = better match)\n"
+    )
+    headers = ["#", "kind", "id", "score", "tags", "snippet"]
+    rows: list[list[str]] = []
+    for i, h in enumerate(hits, 1):
+        rows.append(
+            [
+                str(i),
+                h.kind,
+                str(h.id),
+                f"{h.score:.3f}",
+                _trunc(",".join(h.tags), 24),
+                _trunc(h.snippet, 80),
+            ]
+        )
+    buf.write(_render_table(headers, rows))
+    _session.emit_or_suppress(buf.getvalue().rstrip("\n"))
+    return 0
+
+
 def _cmd_stats(data_dir: Path, args: argparse.Namespace) -> int:
     """Print per-project store stats (human or JSON)."""
     ph = _resolve_project_hash(data_dir, args.project)
@@ -1015,6 +1077,23 @@ def _build_parser() -> argparse.ArgumentParser:
     pst.add_argument("--json", action="store_true",
                      help="emit machine-readable JSON instead of the human format")
 
+    pr = sub.add_parser(
+        "recall",
+        help="full-text search across facts and adrs (FTS5 + bm25)",
+    )
+    pr.add_argument("query", metavar="<query>",
+                    help="search string; wrapped as a phrase unless it contains "
+                         "FTS5 operators (AND/OR/NOT/NEAR, quotes, *, :, ^, parens)")
+    pr.add_argument("--project", default=None,
+                    help="project hash or display_name (default: current cwd)")
+    pr.add_argument("--top", type=int, default=10,
+                    help="maximum number of hits to return (default: 10)")
+    pr.add_argument("--kind", default="all",
+                    choices=["facts", "adrs", "all"],
+                    help="restrict search to one kind (default: all)")
+    pr.add_argument("--json", action="store_true",
+                    help="emit machine-readable JSON instead of the human format")
+
     pu = sub.add_parser(
         "upgrade",
         help="pull the latest mindkeep (pip/pipx auto-detected)",
@@ -1070,6 +1149,8 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_doctor(data_dir)
         if args.cmd == "stats":
             return _cmd_stats(data_dir, args)
+        if args.cmd == "recall":
+            return _cmd_recall(data_dir, args)
         if args.cmd == "upgrade":
             return _cmd_upgrade(args)
         if args.cmd == "session":

--- a/src/mindkeep/memory_api.py
+++ b/src/mindkeep/memory_api.py
@@ -41,9 +41,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import threading
 import uuid
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol, Sequence, runtime_checkable
@@ -131,6 +133,65 @@ def _tags_from_str(raw: str) -> list[str]:
     if not raw:
         return []
     return [t for t in raw.split(",") if t]
+
+
+# ─────────────────────── recall result + query helpers (P0-4) ───────────────────────
+
+
+@dataclass(frozen=True)
+class RecallHit:
+    """One search result from :meth:`MemoryStore.recall`.
+
+    * ``kind``    — ``"fact"`` or ``"adr"``.
+    * ``id``      — primary key in the source table.
+    * ``score``   — raw bm25 (negative-magnitude); **lower is better**.
+    * ``snippet`` — FTS5 ``snippet()`` excerpt with ``[...]`` highlights.
+    * ``tags``    — decoded tag list (empty if the row had no tags).
+    * ``value``   — full source text (facts: ``value``; adrs: ``title``).
+    * ``extra``   — per-kind side-channel fields (e.g. ADR number/status).
+    """
+
+    kind: str
+    id: int
+    score: float
+    snippet: str
+    tags: list[str]
+    value: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain ``dict`` — convenient for JSON serialisation."""
+        return asdict(self)
+
+
+# FTS5 syntax characters that, when present unescaped, indicate the user
+# intends an explicit FTS5 expression (operators, column filters, prefixes,
+# explicit phrases). Anything *not* containing one of these gets wrapped in
+# a phrase quote so punctuation in plain text (".", "/", "-", ":") cannot
+# be misread by the FTS5 parser.
+#
+# Reference: https://sqlite.org/fts5.html#full_text_query_syntax
+_FTS5_OPERATOR_TOKENS = re.compile(
+    r'(?:"|\*|\(|\)|:|\^|\bAND\b|\bOR\b|\bNOT\b|\bNEAR\b)'
+)
+
+
+def _prepare_fts_query(q: str) -> str:
+    """Make ``q`` safe to feed into ``... MATCH ?``.
+
+    If ``q`` already contains FTS5 syntax (operators, quotes, column
+    qualifiers, prefix wildcards, parentheses) we trust it and pass it
+    through. Otherwise we wrap it in a single phrase quote so that
+    incidental punctuation — bare hyphens, dots, slashes, CJK — never
+    triggers the FTS5 parser.
+
+    Inside a phrase quote, the only character that needs escaping is
+    ``"`` itself (FTS5 doubles it).
+    """
+    s = q.strip()
+    if _FTS5_OPERATOR_TOKENS.search(s):
+        return s
+    return '"' + s.replace('"', '""') + '"'
 
 
 # ─────────────────────────── write-guard helpers (P1-7) ───────────────────────────
@@ -684,6 +745,86 @@ class MemoryStore:
     def __exit__(self, exc_type, exc, tb) -> None:
         self.close()
 
+    # ---- full-text recall (P0-4, #9) -------------------------------
+    def recall(
+        self,
+        query: str,
+        *,
+        top: int = 10,
+        kind: str = "all",
+    ) -> list["RecallHit"]:
+        """Full-text search across facts and ADRs (FTS5 + bm25 ranking).
+
+        Parameters
+        ----------
+        query:
+            User-supplied search string. Passed verbatim to FTS5 ``MATCH``
+            after light syntactic protection (see :func:`_prepare_fts_query`):
+            inputs that look like an FTS5 expression go through unchanged;
+            anything else is wrapped in a phrase quote so punctuation,
+            CJK runs, and bare hyphens cannot trip the FTS5 parser.
+        top:
+            Maximum number of hits returned across both kinds (default 10).
+        kind:
+            ``"all"`` (default), ``"facts"``, or ``"adrs"``.
+
+        Returns
+        -------
+        list[RecallHit]
+            Ordered ascending by bm25 score (lower = better, canonical
+            FTS5 semantics). Empty when *query* is blank or there are no
+            matches. Score and snippet come straight from SQLite.
+        """
+        if self._closed:
+            raise RuntimeError("MemoryStore is closed")
+        if kind not in ("all", "facts", "adrs"):
+            raise ValueError(
+                f"unknown kind {kind!r}; allowed: 'all' | 'facts' | 'adrs'"
+            )
+        q = (query or "").strip()
+        if not q:
+            return []
+        prepared = _prepare_fts_query(q)
+        # Pull `top` from each side, merge, then trim — guarantees the
+        # global top-N across kinds even when one side dominates.
+        per_kind = max(1, int(top))
+        hits: list[RecallHit] = []
+        if kind in ("all", "facts"):
+            for r in self._storage.recall_facts(prepared, limit=per_kind):
+                hits.append(
+                    RecallHit(
+                        kind="fact",
+                        id=int(r.get("id", 0)),
+                        score=float(r.get("score", 0.0)),
+                        snippet=str(r.get("snippet", "") or ""),
+                        tags=_tags_from_str(r.get("tags") or ""),
+                        value=str(r.get("value", "") or ""),
+                    )
+                )
+        if kind in ("all", "adrs"):
+            for r in self._storage.recall_adrs(prepared, limit=per_kind):
+                # For ADRs, ``value`` carries the title (the closest
+                # single-line summary); ``decision`` lives in extra so
+                # JSON consumers can introspect if they need to.
+                hits.append(
+                    RecallHit(
+                        kind="adr",
+                        id=int(r.get("id", 0)),
+                        score=float(r.get("score", 0.0)),
+                        snippet=str(r.get("snippet", "") or ""),
+                        tags=_tags_from_str(r.get("tags") or ""),
+                        value=str(r.get("title", "") or ""),
+                        extra={
+                            "number": int(r.get("number", 0)),
+                            "status": str(r.get("status", "") or ""),
+                            "decision": str(r.get("decision", "") or ""),
+                        },
+                    )
+                )
+        # Lower bm25 == better; sort ascending and trim to top.
+        hits.sort(key=lambda h: (h.score, h.kind, h.id))
+        return hits[: max(0, int(top))]
+
     # ---- friendly aliases -----------------------------------
     # Identical to the add_*/list_* methods above — same signatures,
     # same return types, same behavior. Provided so agent-facing code
@@ -694,4 +835,4 @@ class MemoryStore:
     recall_adrs = list_adrs
 
 
-__all__ = ["MemoryStore", "Filter"]
+__all__ = ["MemoryStore", "Filter", "RecallHit"]

--- a/src/mindkeep/storage.py
+++ b/src/mindkeep/storage.py
@@ -877,6 +877,72 @@ class Storage:
                 "newest_fact_at": newest_fact_at,
             }
 
+    # ───────────────────────── full-text recall (P0-4, #9) ─────────────────────────
+    def _fts_available(self) -> bool:
+        """Return True iff facts_fts/adrs_fts virtual tables exist."""
+        try:
+            row = self._conn.execute(
+                "SELECT COUNT(*) AS n FROM sqlite_master "
+                "WHERE type = 'table' AND name IN ('facts_fts', 'adrs_fts')"
+            ).fetchone()
+        except sqlite3.Error:
+            return False
+        return bool(row and int(row["n"]) >= 2)
+
+    def recall_facts(
+        self, query: str, limit: int = 10
+    ) -> list[dict[str, Any]]:
+        """Run an FTS5 MATCH on ``facts_fts`` and return ranked rows.
+
+        Each result dict carries the source ``facts`` columns joined with
+        the bm25-derived ``score`` and an FTS5 ``snippet`` highlighting the
+        first match. Rows are ordered ascending by ``score`` (lower bm25
+        means better — canonical FTS5 semantics).
+
+        Returns an empty list if FTS5 is unavailable or the query is empty.
+        """
+        if not query or not query.strip() or not self._fts_available():
+            return []
+        sql = (
+            "SELECT facts.*, "
+            "       bm25(facts_fts) AS score, "
+            "       snippet(facts_fts, -1, '[', ']', '...', 16) AS snippet "
+            "FROM facts_fts "
+            "JOIN facts ON facts.rowid = facts_fts.rowid "
+            "WHERE facts_fts MATCH ? "
+            "ORDER BY score ASC "
+            "LIMIT ?"
+        )
+        with self._lock:
+            self._ensure_open()
+            rows = self._conn.execute(sql, (query, int(limit))).fetchall()
+            return [dict(r) for r in rows]
+
+    def recall_adrs(
+        self, query: str, limit: int = 10
+    ) -> list[dict[str, Any]]:
+        """Run an FTS5 MATCH on ``adrs_fts`` and return ranked rows.
+
+        Mirrors :meth:`recall_facts`: ascending bm25, FTS5 snippet across
+        all indexed columns (title/decision/context).
+        """
+        if not query or not query.strip() or not self._fts_available():
+            return []
+        sql = (
+            "SELECT adrs.*, "
+            "       bm25(adrs_fts) AS score, "
+            "       snippet(adrs_fts, -1, '[', ']', '...', 16) AS snippet "
+            "FROM adrs_fts "
+            "JOIN adrs ON adrs.rowid = adrs_fts.rowid "
+            "WHERE adrs_fts MATCH ? "
+            "ORDER BY score ASC "
+            "LIMIT ?"
+        )
+        with self._lock:
+            self._ensure_open()
+            rows = self._conn.execute(sql, (query, int(limit))).fetchall()
+            return [dict(r) for r in rows]
+
     def commit(self) -> None:
         with self._lock:
             self._ensure_open()

--- a/tests/test_recall.py
+++ b/tests/test_recall.py
@@ -1,0 +1,296 @@
+"""Tests for the v0.3.0 P0-4 ``mindkeep recall`` command and API (#9).
+
+Covers both the in-process API (``MemoryStore.recall``) and the CLI
+subcommand. Designed to skip cleanly on SQLite builds without FTS5 — the
+P0-4 design treats recall as best-effort on environments lacking FTS5.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mindkeep import cli
+from mindkeep.memory_api import MemoryStore, RecallHit, _prepare_fts_query
+from mindkeep.storage import fts5_available
+
+
+pytestmark = pytest.mark.skipif(
+    not fts5_available(),
+    reason="SQLite build lacks FTS5; recall is unavailable",
+)
+
+
+# ───────────────────────── fixtures ─────────────────────────
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "mem"
+    home.mkdir()
+    monkeypatch.setenv("MINDKEEP_HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+    return home
+
+
+@pytest.fixture
+def populated_store(data_dir: Path):
+    """Open a MemoryStore prefilled with 5 facts + 3 ADRs covering the
+    English/CJK terms used by the assertions below."""
+    store = MemoryStore.open(data_dir=data_dir)
+    # Facts — distinguishable terms.
+    store.add_fact("alpha bravo charlie", tags=["greek", "letters"])
+    store.add_fact("alpha shows up only in this fact", tags=["unique"])
+    store.add_fact("delta echo foxtrot", tags=["alpha"])  # tag-only "alpha"
+    store.add_fact("中文 内容 测试 一", tags=["cjk"])
+    store.add_fact("plain english fact about pnpm install", tags=["build"])
+    # ADRs — separate term universes from the facts so kind filters bite.
+    store.add_adr(
+        title="Adopt zigzag protocol",
+        decision="we will use zigzag for transport",
+        rationale="evaluated quokka and yodel; zigzag wins on latency",
+        tags=["transport"],
+    )
+    store.add_adr(
+        title="Yodel for telemetry",
+        decision="standardise on yodel for metrics",
+        rationale="alpha is rejected as an alternative",
+        tags=["telemetry"],
+    )
+    store.add_adr(
+        title="日志格式 决议",
+        decision="使用 JSON 行格式",
+        rationale="便于 grep 与机器解析",
+        tags=["logging"],
+    )
+    yield store
+    store.close()
+
+
+def _run(argv, capsys):
+    rc = cli.main(argv)
+    cap = capsys.readouterr()
+    return rc, cap.out, cap.err
+
+
+# ───────────────────────── _prepare_fts_query ─────────────────────────
+
+
+def test_prepare_wraps_plain_text():
+    assert _prepare_fts_query("alpha bravo") == '"alpha bravo"'
+
+
+def test_prepare_wraps_punctuation_so_fts_does_not_choke():
+    # bare hyphens / dots / colons are FTS5-significant — must be quoted.
+    assert _prepare_fts_query("foo-bar.baz") == '"foo-bar.baz"'
+
+
+def test_prepare_passes_through_explicit_operator():
+    assert _prepare_fts_query("alpha OR bravo") == "alpha OR bravo"
+
+
+def test_prepare_passes_through_explicit_phrase():
+    assert _prepare_fts_query('"alpha bravo"') == '"alpha bravo"'
+
+
+def test_prepare_passes_through_prefix_wildcard():
+    assert _prepare_fts_query("alph*") == "alph*"
+
+
+def test_prepare_passes_through_when_quote_present():
+    # A bare `"` is itself an FTS5 syntax token (phrase delimiter), so
+    # any input containing one is trusted and forwarded unchanged.
+    assert _prepare_fts_query('He said "hi"') == 'He said "hi"'
+
+
+# ───────────────────────── MemoryStore.recall ─────────────────────────
+
+
+def test_recall_finds_matching_fact(populated_store):
+    hits = populated_store.recall("alpha")
+    assert hits, "expected at least one hit for 'alpha'"
+    assert all(isinstance(h, RecallHit) for h in hits)
+    # The two facts containing the literal word "alpha" must be present.
+    fact_values = {h.value for h in hits if h.kind == "fact"}
+    assert any("alpha bravo charlie" in v for v in fact_values)
+    assert any("alpha shows up only in this fact" in v for v in fact_values)
+
+
+def test_recall_cjk_query(populated_store):
+    hits = populated_store.recall("中文")
+    assert hits, "expected at least one hit for the CJK query"
+    assert any("中文" in h.value or "中文" in h.snippet for h in hits)
+
+
+def test_recall_no_matches_returns_empty(populated_store):
+    assert populated_store.recall("nonexistent_zzzzzz_token") == []
+
+
+def test_recall_empty_query_returns_empty(populated_store):
+    assert populated_store.recall("") == []
+    assert populated_store.recall("   ") == []
+
+
+def test_recall_kind_facts_excludes_adrs(populated_store):
+    hits = populated_store.recall("alpha", kind="facts")
+    assert hits
+    assert all(h.kind == "fact" for h in hits)
+
+
+def test_recall_kind_adrs_excludes_facts(populated_store):
+    # "yodel" appears only in ADRs.
+    hits = populated_store.recall("yodel", kind="adrs")
+    assert hits
+    assert all(h.kind == "adr" for h in hits)
+
+
+def test_recall_kind_all_includes_both(populated_store):
+    # "alpha" appears in facts AND in one ADR's rationale.
+    hits = populated_store.recall("alpha", kind="all", top=20)
+    kinds = {h.kind for h in hits}
+    assert kinds == {"fact", "adr"}
+
+
+def test_recall_top_one(populated_store):
+    hits = populated_store.recall("alpha", top=1)
+    assert len(hits) == 1
+
+
+def test_recall_results_sorted_by_score_ascending(populated_store):
+    hits = populated_store.recall("alpha", top=20)
+    assert hits == sorted(hits, key=lambda h: (h.score, h.kind, h.id))
+
+
+def test_recall_unknown_kind_raises(populated_store):
+    with pytest.raises(ValueError):
+        populated_store.recall("alpha", kind="bogus")
+
+
+def test_recall_snippet_highlights_match(populated_store):
+    hits = populated_store.recall("alpha", kind="facts", top=5)
+    # FTS5 snippet() wraps matches with the `[ ]` markers we requested.
+    assert any("[" in h.snippet and "]" in h.snippet for h in hits)
+
+
+def test_recall_ranking_documented(populated_store):
+    """Document the actual bm25 ordering with default column weights.
+
+    bm25 rewards short documents matching rare terms. The tag-only fact
+    ``"delta echo foxtrot"`` (tags=``alpha``) is a shorter "document"
+    overall than ``"alpha bravo charlie"`` (tags=``greek,letters``) once
+    you sum value+tags lengths, so it can legitimately rank first. We
+    don't assert a specific ordering — only that all three "alpha"-
+    bearing facts appear, are deterministically sorted, and that scores
+    are non-decreasing (lower bm25 = better, ascending).
+    """
+    hits = populated_store.recall("alpha", kind="facts", top=10)
+    values = [h.value for h in hits]
+    assert any("alpha bravo" in v for v in values)
+    assert any(v.startswith("alpha shows up") for v in values)
+    assert any(v.startswith("delta") for v in values)  # tag-only match
+    scores = [h.score for h in hits]
+    assert scores == sorted(scores)
+
+
+# ───────────────────────── CLI surface ─────────────────────────
+
+
+def _seed(data_dir: Path) -> None:
+    """Same fixture content as ``populated_store``, but as a freshly-closed
+    store so the CLI subcommand can re-open it."""
+    store = MemoryStore.open(data_dir=data_dir)
+    store.add_fact("alpha bravo charlie", tags=["greek"])
+    store.add_fact("alpha shows up only in this fact")
+    store.add_fact("delta echo foxtrot", tags=["alpha"])
+    store.add_fact("中文 内容 测试 一", tags=["cjk"])
+    store.add_fact("pnpm install fact", tags=["build"])
+    store.add_adr(
+        title="Adopt zigzag protocol",
+        decision="we will use zigzag",
+        rationale="evaluated alternatives",
+    )
+    store.add_adr(
+        title="Yodel for telemetry",
+        decision="standardise on yodel",
+        rationale="alpha is rejected as an alternative",
+    )
+    store.close()
+
+
+def test_cli_recall_human_format(data_dir, capsys):
+    _seed(data_dir)
+    rc, out, err = _run(["recall", "alpha"], capsys)
+    assert rc == 0, err
+    assert "recall:" in out
+    assert "lower bm25 = better match" in out
+    assert "kind" in out and "score" in out
+
+
+def test_cli_recall_no_matches(data_dir, capsys):
+    _seed(data_dir)
+    rc, out, _ = _run(["recall", "nonexistent_xyz_token"], capsys)
+    assert rc == 0
+    assert "No results." in out
+
+
+def test_cli_recall_no_matches_json(data_dir, capsys):
+    _seed(data_dir)
+    rc, out, _ = _run(["recall", "nonexistent_xyz_token", "--json"], capsys)
+    assert rc == 0
+    assert json.loads(out) == []
+
+
+def test_cli_recall_empty_query_exits_2(data_dir, capsys):
+    _seed(data_dir)
+    rc, _, err = _run(["recall", "   "], capsys)
+    assert rc == 2
+    assert "non-empty" in err
+
+
+def test_cli_recall_json_shape(data_dir, capsys):
+    _seed(data_dir)
+    rc, out, err = _run(["recall", "alpha", "--json"], capsys)
+    assert rc == 0, err
+    data = json.loads(out)
+    assert isinstance(data, list)
+    assert data, "expected at least one hit"
+    required = {"kind", "id", "score", "snippet", "tags", "value"}
+    for entry in data:
+        assert required.issubset(entry.keys())
+        assert entry["kind"] in {"fact", "adr"}
+        assert isinstance(entry["id"], int)
+        assert isinstance(entry["score"], (int, float))
+        assert isinstance(entry["tags"], list)
+
+
+def test_cli_recall_kind_facts(data_dir, capsys):
+    _seed(data_dir)
+    rc, out, _ = _run(["recall", "alpha", "--kind", "facts", "--json"], capsys)
+    assert rc == 0
+    data = json.loads(out)
+    assert data and all(d["kind"] == "fact" for d in data)
+
+
+def test_cli_recall_kind_adrs(data_dir, capsys):
+    _seed(data_dir)
+    rc, out, _ = _run(["recall", "yodel", "--kind", "adrs", "--json"], capsys)
+    assert rc == 0
+    data = json.loads(out)
+    assert data and all(d["kind"] == "adr" for d in data)
+
+
+def test_cli_recall_top_limits(data_dir, capsys):
+    _seed(data_dir)
+    rc, out, _ = _run(["recall", "alpha", "--top", "1", "--json"], capsys)
+    assert rc == 0
+    assert len(json.loads(out)) == 1
+
+
+def test_cli_recall_cjk(data_dir, capsys):
+    _seed(data_dir)
+    rc, out, _ = _run(["recall", "中文", "--json"], capsys)
+    assert rc == 0
+    data = json.loads(out)
+    assert data
+    assert any("中文" in d["value"] or "中文" in d["snippet"] for d in data)


### PR DESCRIPTION
Closes #9.

Adds the v0.3.0 P0-4 `mindkeep recall` subcommand and matching `MemoryStore.recall` API. Uses the FTS5 virtual tables provisioned in #17, bm25() for ranking (lower = better, ascending sort), and FTS5 snippet() for highlighted excerpts.

## API
- `MemoryStore.recall(query, *, top=10, kind='all') -> list[RecallHit]`  
- New `RecallHit` dataclass (`kind`/`id`/`score`/`snippet`/`tags`/`value`/`extra`) with `to_dict()` for JSON.
- `_prepare_fts_query` wraps plain text in a phrase quote so punctuation/CJK never trips the FTS5 parser; passes through explicit FTS5 expressions (`AND`/`OR`/`NOT`/`NEAR`/quotes/`*`/`:`/`^`/parens).
- `Storage.recall_facts` / `Storage.recall_adrs` run `MATCH` + `bm25()` + `snippet()`; gracefully no-op when FTS5 is not compiled in.

## CLI
- `mindkeep recall <query> [--project ...] [--top K] [--kind facts|adrs|all] [--json]`.
- Default human output: ranked table (`# | kind | id | score | tags | snippet`) with the documented `lower bm25 = better match` header.
- `--json` emits `[{kind,id,score,snippet,tags,value,extra}]`.
- Honors the session budget via the same StringIO-buffering pattern as `_cmd_show`.
- Empty/whitespace query → exit 2 with a friendly stderr message; no matches → `No results.` (or `[]` for `--json`), exit 0.

## Tests
`tests/test_recall.py`: 27 new cases covering the query-prep helper, `MemoryStore.recall` (English + CJK, `--kind` filters, `--top`, empty query, snippet brackets, sort invariants, deterministic bm25 ordering), and the CLI surface (human + JSON, both kinds, empty-query exit 2, no-match path). Marked `skipif` for SQLite builds without FTS5. Total `237` pass locally (210 baseline + 27 new).