### PR TITLE
feat(cli): doctor — schema/wal/fts5/cap/stale/pin checks (P1-9, #14)

### DIFF
--- a/src/mindkeep/cli.py
+++ b/src/mindkeep/cli.py
@@ -589,10 +589,16 @@ def _cmd_where(data_dir: Path) -> int:
 # ───────────────────────── command: doctor ─────────────────────────
 
 
-def _cmd_doctor(data_dir: Path) -> int:
-    """Environment health check. Prints ✅/❌/⚠️ per item.
+def _cmd_doctor(data_dir: Path, args: argparse.Namespace | None = None) -> int:
+    """Environment + store health checks.
 
-    Exit 0 if no ❌ (warnings allowed); non-zero if any ❌.
+    Emits a list of checks, each ``OK`` / ``WARN`` / ``FAIL``. Exit code is
+    ``0`` if no ``FAIL`` (warnings are tolerated), ``1`` otherwise. Use
+    ``--json`` for machine-readable output (schema ``{"version": 1,
+    "checks": [...], "summary": {"ok", "warn", "fail"}}``).
+
+    A missing project DB is *not* a failure — it surfaces as a single
+    ``WARN`` so ``mindkeep doctor`` remains a useful setup probe.
     """
     import importlib
     import importlib.metadata as _md
@@ -600,44 +606,70 @@ def _cmd_doctor(data_dir: Path) -> int:
     import sysconfig
     import tempfile
 
-    errors = 0
-    warnings = 0
+    json_mode = bool(getattr(args, "json", False)) if args is not None else False
 
-    def ok(msg: str) -> None:
-        print(f"✅ {msg}")
+    checks: list[dict[str, Any]] = []
 
-    def bad(msg: str) -> None:
-        nonlocal errors
-        errors += 1
-        print(f"❌ {msg}")
+    def _emit(check_id: str, status: str, msg: str,
+              details: dict[str, Any] | None = None) -> None:
+        entry: dict[str, Any] = {
+            "id": check_id,
+            "status": status,
+            "message": msg,
+        }
+        if details:
+            entry["details"] = details
+        checks.append(entry)
+        if json_mode:
+            return
+        glyph = {"OK": "✅", "WARN": "⚠️ ", "FAIL": "❌"}[status]
+        if status == "OK":
+            print(f"{glyph} {msg}")
+        else:
+            print(f"{glyph} {msg}")
 
-    def warn(msg: str) -> None:
-        nonlocal warnings
-        warnings += 1
-        print(f"⚠️  {msg}")
+    def ok(cid: str, msg: str, details: dict[str, Any] | None = None) -> None:
+        _emit(cid, "OK", msg, details)
 
-    print("mindkeep doctor")
-    print("-" * 40)
+    def warn(cid: str, msg: str, details: dict[str, Any] | None = None) -> None:
+        _emit(cid, "WARN", msg, details)
 
-    # 1. Python version
+    def bad(cid: str, msg: str, details: dict[str, Any] | None = None) -> None:
+        _emit(cid, "FAIL", msg, details)
+
+    def section(title: str) -> None:
+        if json_mode:
+            return
+        print()
+        print(title)
+        print("-" * 40)
+
+    if not json_mode:
+        print("mindkeep doctor")
+        print("-" * 40)
+
+    section("Environment")
+
     v = sys.version_info
     py = f"{v.major}.{v.minor}.{v.micro}"
     if (v.major, v.minor) >= (3, 9):
-        ok(f"Python version: {py} (>= 3.9)")
+        ok("python-version", f"Python version: {py} (>= 3.9)",
+           {"version": py})
     else:
-        bad(f"Python version: {py} (need >= 3.9)")
+        bad("python-version", f"Python version: {py} (need >= 3.9)",
+            {"version": py})
 
-    # 2. mindkeep package installed
     try:
         pkg_version = _md.version("mindkeep")
-        ok(f"mindkeep installed: {pkg_version}")
+        ok("package-installed", f"mindkeep installed: {pkg_version}",
+           {"version": pkg_version})
     except _md.PackageNotFoundError:
-        bad("mindkeep not installed (importlib.metadata lookup failed)")
+        bad("package-installed",
+            "mindkeep not installed (importlib.metadata lookup failed)")
 
-    # 3. CLI on PATH
     exe = shutil.which("mindkeep")
     if exe:
-        ok(f"CLI on PATH: {exe}")
+        ok("cli-on-path", f"CLI on PATH: {exe}", {"path": exe})
     else:
         try:
             scripts_dir = sysconfig.get_path(
@@ -649,19 +681,22 @@ def _cmd_doctor(data_dir: Path) -> int:
             hint = f'$env:Path += ";{scripts_dir}"'
         else:
             hint = 'export PATH="$HOME/.local/bin:$PATH"'
-        warn(f"'mindkeep' not in PATH; add scripts dir: {hint}")
+        warn("cli-on-path",
+             f"'mindkeep' not in PATH; add scripts dir: {hint}",
+             {"scripts_dir": scripts_dir})
 
-    # 4. Data dir writable
     try:
         data_dir.mkdir(parents=True, exist_ok=True)
         probe = data_dir / ".health"
         probe.write_text("ok", encoding="utf-8")
         probe.unlink()
-        ok(f"Data dir writable: {data_dir}")
+        ok("data-dir-writable", f"Data dir writable: {data_dir}",
+           {"data_dir": str(data_dir)})
     except (OSError, PermissionError) as exc:
-        bad(f"Data dir not writable ({data_dir}): {exc}")
+        bad("data-dir-writable",
+            f"Data dir not writable ({data_dir}): {exc}",
+            {"data_dir": str(data_dir), "error": str(exc)})
 
-    # 5. SQLite WAL support
     try:
         with tempfile.TemporaryDirectory() as td:
             db_path = Path(td) / "probe.db"
@@ -671,53 +706,310 @@ def _cmd_doctor(data_dir: Path) -> int:
             finally:
                 conn.close()
         if str(mode).lower() == "wal":
-            ok("SQLite WAL mode supported")
+            ok("sqlite-wal-supported", "SQLite WAL mode supported",
+               {"journal_mode": str(mode)})
         else:
-            warn(f"SQLite journal_mode returned '{mode}' (expected 'wal')")
+            warn("sqlite-wal-supported",
+                 f"SQLite journal_mode returned '{mode}' (expected 'wal')",
+                 {"journal_mode": str(mode)})
     except sqlite3.Error as exc:
-        bad(f"SQLite WAL probe failed: {exc}")
+        bad("sqlite-wal-supported", f"SQLite WAL probe failed: {exc}",
+            {"error": str(exc)})
 
-    # 6. Filters (SecretsRedactor) loadable
     try:
         mod = importlib.import_module("mindkeep.security")
         redactor_cls = getattr(mod, "SecretsRedactor")
         redactor_cls()
-        ok("Filters loaded: SecretsRedactor OK")
+        ok("filters-loaded", "Filters loaded: SecretsRedactor OK")
     except Exception as exc:
-        bad(f"SecretsRedactor failed to load: {exc}")
+        bad("filters-loaded", f"SecretsRedactor failed to load: {exc}",
+            {"error": str(exc)})
 
-    # 7. Current project identification
+    pid = None
     try:
         pid = resolve_project_id()
-        ok(
-            f"Current project: id={pid.id} source={pid.source} "
-            f"display_name={pid.display_name}"
-        )
+        ok("current-project",
+           f"Current project: id={pid.id} source={pid.source} "
+           f"display_name={pid.display_name}",
+           {"id": pid.id, "source": pid.source,
+            "display_name": pid.display_name})
     except Exception as exc:
-        bad(f"resolve_project_id() failed: {exc}")
+        bad("current-project", f"resolve_project_id() failed: {exc}",
+            {"error": str(exc)})
 
-    # 8. Existing project count
     try:
         if data_dir.exists():
             dbs = [
                 p for p in data_dir.glob("*.db")
                 if p.name != "preferences.db"
             ]
-            ok(f"Known projects: {len(dbs)} DB file(s) in {data_dir}")
+            ok("known-projects",
+               f"Known projects: {len(dbs)} DB file(s) in {data_dir}",
+               {"count": len(dbs), "data_dir": str(data_dir)})
         else:
-            warn(f"Data dir does not exist yet: {data_dir}")
+            warn("known-projects",
+                 f"Data dir does not exist yet: {data_dir}",
+                 {"data_dir": str(data_dir)})
     except OSError as exc:
-        warn(f"Could not enumerate project DBs: {exc}")
+        warn("known-projects",
+             f"Could not enumerate project DBs: {exc}",
+             {"error": str(exc)})
 
-    print("-" * 40)
-    if errors == 0 and warnings == 0:
-        print("All checks passed 🎉")
-        return 0
-    if errors == 0:
-        print("Some warnings, you may proceed")
-        return 0
-    print("Run with --fix to attempt auto-repair (not yet implemented)")
-    return 1
+    section("Store health")
+    _run_store_checks(data_dir, pid, ok, warn, bad)
+
+    summary = {
+        "ok": sum(1 for c in checks if c["status"] == "OK"),
+        "warn": sum(1 for c in checks if c["status"] == "WARN"),
+        "fail": sum(1 for c in checks if c["status"] == "FAIL"),
+    }
+
+    if json_mode:
+        print(json.dumps(
+            {"version": 1, "checks": checks, "summary": summary},
+            indent=2, sort_keys=False,
+        ))
+    else:
+        print()
+        print("-" * 40)
+        if summary["fail"] == 0 and summary["warn"] == 0:
+            print("All checks passed 🎉")
+        elif summary["fail"] == 0:
+            print(
+                f"Some warnings ({summary['warn']}), you may proceed"
+            )
+        else:
+            print(
+                f"{summary['fail']} failing check(s), "
+                f"{summary['warn']} warning(s)"
+            )
+            print("Run with --fix to attempt auto-repair (not yet implemented)")
+
+    return 1 if summary["fail"] else 0
+
+
+def _run_store_checks(
+    data_dir: Path,
+    pid: ProjectId | None,
+    ok,  # type: ignore[no-untyped-def]
+    warn,  # type: ignore[no-untyped-def]
+    bad,  # type: ignore[no-untyped-def]
+) -> None:
+    """Per-project DB health checks (P1-9). Gracefully skips if no DB.
+
+    A missing DB → single ``WARN`` for ``store-database``; the dependent
+    checks (schema, wal, fts5, stats, cap-pressure, stale, db-size, pin)
+    are skipped.
+    """
+    if pid is None:
+        warn("store-database",
+             "no project DB checks (project id unavailable)")
+        return
+
+    db_path = data_dir / f"{pid.id}.db"
+    if not db_path.exists():
+        warn("store-database",
+             f"no database initialised yet at {db_path} — "
+             f"add a fact to create one",
+             {"db_path": str(db_path)})
+        return
+
+    from .memory_api import _resolve_cap
+
+    try:
+        s = Storage(pid.id, data_dir=data_dir)
+    except Exception as exc:
+        bad("store-database",
+            f"failed to open project DB ({db_path}): {exc}",
+            {"db_path": str(db_path), "error": str(exc)})
+        return
+
+    try:
+        # Check 1 — schema version up-to-date
+        try:
+            row = s._conn.execute(
+                "SELECT schema_version FROM meta WHERE id = 1"
+            ).fetchone()
+            db_schema = int(row["schema_version"]) if row else None
+        except sqlite3.Error as exc:
+            bad("schema-version",
+                f"could not read meta.schema_version: {exc}",
+                {"error": str(exc)})
+            db_schema = None
+        if db_schema is not None:
+            details = {"db": db_schema, "expected": SCHEMA_VERSION}
+            if db_schema == SCHEMA_VERSION:
+                ok("schema-version",
+                   f"Schema version up-to-date: {db_schema}", details)
+            elif db_schema < SCHEMA_VERSION:
+                warn("schema-version",
+                     f"Schema version {db_schema} older than expected "
+                     f"{SCHEMA_VERSION}; run an operation to migrate",
+                     details)
+            else:
+                bad("schema-version",
+                    f"Schema version {db_schema} NEWER than this "
+                    f"binary supports ({SCHEMA_VERSION}); upgrade mindkeep",
+                    details)
+
+        # Check 2 — WAL mode active on this DB
+        try:
+            mode_row = s._conn.execute("PRAGMA journal_mode").fetchone()
+            mode = str(mode_row[0]).lower() if mode_row else ""
+        except sqlite3.Error as exc:
+            bad("wal-mode-active",
+                f"PRAGMA journal_mode failed: {exc}", {"error": str(exc)})
+            mode = ""
+        if mode == "wal":
+            ok("wal-mode-active", "WAL mode active on project DB",
+               {"journal_mode": mode})
+        elif mode:
+            warn("wal-mode-active",
+                 f"journal_mode is '{mode}', expected 'wal' "
+                 f"(concurrency degraded)",
+                 {"journal_mode": mode})
+
+        # Check 3 — FTS5 integrity
+        try:
+            s._conn.execute(
+                "INSERT INTO facts_fts(facts_fts) VALUES('integrity-check')"
+            )
+            ok("fts5-integrity", "FTS5 integrity check passed")
+        except sqlite3.Error as exc:
+            bad("fts5-integrity", f"FTS5 integrity check failed: {exc}",
+                {"error": str(exc)})
+
+        # Check 4 — Storage stats summary
+        try:
+            stats_data = s.stats()
+            facts_total = stats_data["facts"]["total"]
+            adrs_total = stats_data["adrs"]["total"]
+            tokens_total = stats_data["tokens_estimated_total"]
+            facts_pinned = stats_data["facts"]["pinned"]
+            adrs_pinned = stats_data["adrs"]["pinned"]
+            ok("store-stats",
+               f"Store stats: {facts_total} fact(s), {adrs_total} adr(s), "
+               f"~{tokens_total} tokens, "
+               f"pinned facts={facts_pinned} adrs={adrs_pinned}",
+               {
+                   "facts_total": facts_total,
+                   "adrs_total": adrs_total,
+                   "tokens_estimated_total": tokens_total,
+                   "facts_pinned": facts_pinned,
+                   "adrs_pinned": adrs_pinned,
+                   "db_size_bytes": stats_data["db_size_bytes"],
+               })
+        except sqlite3.Error as exc:
+            bad("store-stats", f"stats() failed: {exc}", {"error": str(exc)})
+            stats_data = None
+
+        # Check 5 — Token-cap pressure
+        try:
+            fact_cap = _resolve_cap("fact")
+            adr_cap = _resolve_cap("adr")
+            fact_thresh = int(0.8 * fact_cap)
+            adr_thresh = int(0.8 * adr_cap)
+            f_near = s._conn.execute(
+                "SELECT COUNT(*) AS n FROM facts "
+                "WHERE token_estimate IS NOT NULL AND token_estimate > ?",
+                (fact_thresh,),
+            ).fetchone()["n"]
+            a_near = s._conn.execute(
+                "SELECT COUNT(*) AS n FROM adrs "
+                "WHERE token_estimate IS NOT NULL AND token_estimate > ?",
+                (adr_thresh,),
+            ).fetchone()["n"]
+            details = {
+                "fact_cap": fact_cap,
+                "adr_cap": adr_cap,
+                "facts_near_cap": int(f_near),
+                "adrs_near_cap": int(a_near),
+                "threshold_pct": 80,
+            }
+            if f_near or a_near:
+                warn("token-cap-pressure",
+                     f"{f_near} fact(s) and {a_near} adr(s) above 80% of "
+                     f"their token caps ({fact_cap}/{adr_cap}); review "
+                     f"or archive",
+                     details)
+            else:
+                ok("token-cap-pressure",
+                   f"No entries above 80% of token caps "
+                   f"(facts cap={fact_cap}, adrs cap={adr_cap})",
+                   details)
+        except sqlite3.Error as exc:
+            bad("token-cap-pressure",
+                f"cap pressure query failed: {exc}", {"error": str(exc)})
+
+        # Check 6 — Stale entries (informational)
+        try:
+            from datetime import datetime, timedelta, timezone
+            cutoff = (datetime.now(timezone.utc)
+                      - timedelta(days=90)).isoformat()
+            stale_facts = s._conn.execute(
+                "SELECT COUNT(*) AS n FROM facts "
+                "WHERE last_accessed_at IS NULL OR last_accessed_at < ?",
+                (cutoff,),
+            ).fetchone()["n"]
+            stale_adrs = s._conn.execute(
+                "SELECT COUNT(*) AS n FROM adrs "
+                "WHERE last_accessed_at IS NULL OR last_accessed_at < ?",
+                (cutoff,),
+            ).fetchone()["n"]
+            ok("stale-entries",
+               f"Stale entries (>90d or never accessed): "
+               f"{stale_facts} fact(s), {stale_adrs} adr(s)",
+               {
+                   "stale_facts": int(stale_facts),
+                   "stale_adrs": int(stale_adrs),
+                   "days": 90,
+               })
+        except sqlite3.Error as exc:
+            bad("stale-entries", f"stale query failed: {exc}",
+                {"error": str(exc)})
+
+        # Check 7 — DB file size & VACUUM hint
+        try:
+            size = db_path.stat().st_size
+            free_pages = int(s._conn.execute(
+                "PRAGMA freelist_count"
+            ).fetchone()[0])
+            page_count = int(s._conn.execute(
+                "PRAGMA page_count"
+            ).fetchone()[0])
+            free_ratio = (free_pages / page_count) if page_count else 0.0
+            details = {
+                "db_size_bytes": size,
+                "free_pages": free_pages,
+                "page_count": page_count,
+                "free_ratio": round(free_ratio, 4),
+            }
+            if size > 50 * 1024 * 1024 and free_ratio > 0.30:
+                warn("db-size-vacuum",
+                     f"DB is {size} bytes with "
+                     f"{free_pages}/{page_count} free pages "
+                     f"({free_ratio:.0%}); consider VACUUM",
+                     details)
+            else:
+                ok("db-size-vacuum",
+                   f"DB size {size} bytes "
+                   f"({free_pages}/{page_count} free pages)",
+                   details)
+        except (OSError, sqlite3.Error) as exc:
+            bad("db-size-vacuum", f"size probe failed: {exc}",
+                {"error": str(exc)})
+
+        # Check 8 — Pin sanity
+        if stats_data is not None:
+            ok("pin-sanity",
+               f"Pinned: {stats_data['facts']['pinned']} fact(s), "
+               f"{stats_data['adrs']['pinned']} adr(s)",
+               {
+                   "facts_pinned": stats_data["facts"]["pinned"],
+                   "adrs_pinned": stats_data["adrs"]["pinned"],
+               })
+    finally:
+        s.close()
 
 
 # ───────────────────────── argparse plumbing ─────────────────────────
@@ -1007,7 +1299,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("where", help="print data_dir and current project id")
 
-    sub.add_parser("doctor", help="run environment health checks")
+    pdoc = sub.add_parser("doctor", help="run environment health checks")
+    pdoc.add_argument("--json", action="store_true",
+                      help="emit machine-readable JSON instead of human format")
 
     pst = sub.add_parser("stats", help="print introspection stats for a project")
     pst.add_argument("--project", default=None,
@@ -1067,7 +1361,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.cmd == "where":
             return _cmd_where(data_dir)
         if args.cmd == "doctor":
-            return _cmd_doctor(data_dir)
+            return _cmd_doctor(data_dir, args)
         if args.cmd == "stats":
             return _cmd_stats(data_dir, args)
         if args.cmd == "upgrade":

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,174 @@
+"""Tests for the enhanced ``mindkeep doctor`` (P1-9, issue #14)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mindkeep import cli
+from mindkeep.memory_api import MemoryStore
+from mindkeep.storage import SCHEMA_VERSION, Storage
+
+
+# ───────────────────────── fixtures ─────────────────────────
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "mem"
+    home.mkdir()
+    monkeypatch.setenv("MINDKEEP_HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+    return home
+
+
+def _seed(data_dir: Path, cwd: Path, *, facts: int = 0, adrs: int = 0) -> str:
+    cwd.mkdir(exist_ok=True)
+    store = MemoryStore.open(cwd=cwd, data_dir=data_dir)
+    try:
+        for i in range(facts):
+            store.add_fact(f"fact-{i}", tags=["t"])
+        for i in range(adrs):
+            store.add_adr(f"ADR {i}", "do X", "because Y")
+        return store.project_id.id
+    finally:
+        store.close()
+
+
+def _run(argv: list[str], capsys) -> tuple[int, str, str]:
+    rc = cli.main(argv)
+    cap = capsys.readouterr()
+    return rc, cap.out, cap.err
+
+
+# ───────────────────────── tests ─────────────────────────
+
+
+def test_doctor_missing_db_warns_exit_zero(data_dir: Path, capsys):
+    rc, out, _ = _run(["doctor"], capsys)
+    assert rc == 0
+    assert "no database initialised" in out
+
+
+def test_doctor_json_schema_missing_db(data_dir: Path, capsys):
+    rc, out, _ = _run(["doctor", "--json"], capsys)
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["version"] == 1
+    assert isinstance(payload["checks"], list)
+    assert {"ok", "warn", "fail"} == set(payload["summary"].keys())
+    assert payload["summary"]["fail"] == 0
+    for c in payload["checks"]:
+        assert {"id", "status", "message"} <= set(c.keys())
+        assert c["status"] in {"OK", "WARN", "FAIL"}
+    ids = {c["id"] for c in payload["checks"]}
+    assert "store-database" in ids
+    # No project DB → store-health subchecks skipped.
+    assert "schema-version" not in ids
+
+
+def test_doctor_fresh_db_all_checks_pass(
+    data_dir: Path, tmp_path: Path, monkeypatch, capsys,
+):
+    sub = tmp_path / "fresh"
+    _seed(data_dir, sub)
+    monkeypatch.chdir(sub)
+    rc, out, _ = _run(["doctor", "--json"], capsys)
+    assert rc == 0
+    payload = json.loads(out)
+    by_id = {c["id"]: c for c in payload["checks"]}
+    assert by_id["schema-version"]["status"] == "OK"
+    assert by_id["schema-version"]["details"]["db"] == SCHEMA_VERSION
+    assert by_id["wal-mode-active"]["status"] == "OK"
+    assert by_id["fts5-integrity"]["status"] == "OK"
+    assert by_id["store-stats"]["status"] == "OK"
+    assert by_id["store-stats"]["details"]["facts_total"] == 0
+    assert by_id["store-stats"]["details"]["adrs_total"] == 0
+    assert by_id["token-cap-pressure"]["status"] == "OK"
+    assert by_id["stale-entries"]["status"] == "OK"
+    assert by_id["db-size-vacuum"]["status"] == "OK"
+    assert by_id["pin-sanity"]["status"] == "OK"
+    assert payload["summary"]["fail"] == 0
+
+
+def test_doctor_counts_after_inserts(
+    data_dir: Path, tmp_path: Path, monkeypatch, capsys,
+):
+    sub = tmp_path / "seeded"
+    _seed(data_dir, sub, facts=3, adrs=2)
+    monkeypatch.chdir(sub)
+    rc, out, _ = _run(["doctor", "--json"], capsys)
+    assert rc == 0
+    payload = json.loads(out)
+    by_id = {c["id"]: c for c in payload["checks"]}
+    assert by_id["store-stats"]["details"]["facts_total"] == 3
+    assert by_id["store-stats"]["details"]["adrs_total"] == 2
+    assert by_id["store-stats"]["details"]["tokens_estimated_total"] > 0
+    # New rows have last_accessed_at NULL → counted as "stale" by design.
+    assert by_id["stale-entries"]["details"]["stale_facts"] == 3
+
+
+def test_doctor_cap_pressure_warns(
+    data_dir: Path, tmp_path: Path, monkeypatch, capsys,
+):
+    sub = tmp_path / "near_cap"
+    sub.mkdir()
+    store = MemoryStore.open(cwd=sub, data_dir=data_dir)
+    try:
+        # Long value: ~ (chars/4) tokens ≫ 80% of default 100 fact cap.
+        store.add_fact("a" * 600, force=True)
+    finally:
+        store.close()
+    monkeypatch.chdir(sub)
+    rc, out, _ = _run(["doctor", "--json"], capsys)
+    assert rc == 0
+    payload = json.loads(out)
+    by_id = {c["id"]: c for c in payload["checks"]}
+    assert by_id["token-cap-pressure"]["status"] == "WARN"
+    assert by_id["token-cap-pressure"]["details"]["facts_near_cap"] >= 1
+    assert payload["summary"]["fail"] == 0
+
+
+def test_doctor_human_format_renders_sections(
+    data_dir: Path, tmp_path: Path, monkeypatch, capsys,
+):
+    sub = tmp_path / "human"
+    _seed(data_dir, sub, facts=1)
+    monkeypatch.chdir(sub)
+    rc, out, _ = _run(["doctor"], capsys)
+    assert rc == 0
+    assert "mindkeep doctor" in out
+    assert "Environment" in out
+    assert "Store health" in out
+    assert "Schema version up-to-date" in out
+    assert "FTS5 integrity check passed" in out
+    assert "Store stats:" in out
+
+
+def test_doctor_warn_only_exits_zero(
+    data_dir: Path, tmp_path: Path, monkeypatch, capsys,
+):
+    # Default fixture leaves no DB; cli-on-path may already be OK. Force
+    # at least one WARN by leaving DB missing → store-database WARN.
+    rc, _, _ = _run(["doctor"], capsys)
+    assert rc == 0
+
+
+def test_doctor_schema_version_newer_fails(
+    data_dir: Path, tmp_path: Path, monkeypatch, capsys,
+):
+    sub = tmp_path / "newer"
+    _seed(data_dir, sub)
+    monkeypatch.chdir(sub)
+    # Pretend this binary is older than the on-disk schema. Patch the
+    # constant the doctor compares against (Storage open re-stamps the DB
+    # to its own SCHEMA_VERSION via migrate_to_v3, so we can't simply bump
+    # meta.schema_version directly).
+    monkeypatch.setattr(cli, "SCHEMA_VERSION", SCHEMA_VERSION - 1)
+    rc, out, _ = _run(["doctor", "--json"], capsys)
+    assert rc == 1
+    payload = json.loads(out)
+    by_id = {c["id"]: c for c in payload["checks"]}
+    assert by_id["schema-version"]["status"] == "FAIL"
+    assert payload["summary"]["fail"] >= 1


### PR DESCRIPTION
Closes #14

Extends mindkeep doctor with project-store health checks (built on the P1-6 stats infrastructure):

- **schema-version** — WARN if older than storage.SCHEMA_VERSION, FAIL if newer.
- **wal-mode-active** — PRAGMA journal_mode on the project DB.
- **fts5-integrity** — runs INSERT INTO facts_fts(facts_fts) VALUES('integrity-check').
- **store-stats** — fact/adr counts, total estimated tokens, pin counts.
- **token-cap-pressure** — facts/adrs above 80% of MINDKEEP_FACTS_TOKEN_CAP / MINDKEEP_ADRS_TOKEN_CAP.
- **stale-entries** — rows whose last_accessed_at is NULL or older than 90 days.
- **db-size-vacuum** — WARN when DB > 50MB and freelist_count > 30% of pages.
- **pin-sanity** — informational pin counts.

`--json` emits `{version: 1, checks: [...], summary: {ok, warn, fail}}`. Exit code is 0 unless a check FAILs (warnings are tolerated). Missing DB → single friendly WARN, exit 0.

Tests in `tests/test_doctor.py` cover fresh DB, seeded counts, near-cap WARN, JSON schema, FTS5 integrity, missing-DB friendly WARN, schema-newer FAIL, and human-format sectioning. Full suite: 218 passed.