### PR TITLE
feat(cli): mindkeep integrate <claude|copilot|cursor|generic> (P1-5, #10)

### DIFF
--- a/src/mindkeep/_integrations.py
+++ b/src/mindkeep/_integrations.py
@@ -1,0 +1,244 @@
+"""Integration snippet templates for `mindkeep integrate <target>`.
+
+Each template is a ready-to-paste markdown block that instructs an AI coding
+agent how to use mindkeep as project memory: silent session-start dumps,
+targeted recall, and proactive capture via the Python API. Templates are kept
+deliberately minimal and free of user-specific paths so they're safe to drop
+into any agent-instructions file.
+"""
+
+from __future__ import annotations
+
+CLAUDE = """\
+# Project memory (mindkeep)
+
+At the start of every session, if `mindkeep` is on PATH and the current working
+directory is **not** the user's home directory or a system temp dir, silently run:
+
+- `mindkeep show --kind facts`
+- `mindkeep show --kind adrs`
+- `mindkeep show --kind sessions --limit 3`
+
+Treat the output as authoritative project context for this Claude session. Do
+not announce the lookup unless results are non-empty — if there are facts or
+ADRs, briefly summarize them as "🧠 mindkeep recall: …" so the user knows the
+context was loaded. If results are empty, stay silent.
+
+If `mindkeep` is not installed, skip silently.
+
+## Targeted lookup
+
+Before answering any non-trivial question about this project, run:
+
+- `mindkeep recall "<query>"` — full-text search across facts and ADRs.
+
+## When to write to mindkeep
+
+Capture durable signal proactively (don't wait for the user to ask):
+
+- **Facts** — non-obvious project truths worth remembering across sessions:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().add_fact('<content>', tags=['<tag>'])"
+  ```
+
+- **ADRs** — architectural decisions with rationale:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().add_adr(title='<title>', decision='<what>', rationale='<why>')"
+  ```
+
+- **Preferences** — durable user/project settings:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().set_preference('<key>', '<value>')"
+  ```
+
+Tell the user concisely when you've recorded something:
+"📝 Saved to mindkeep: <fact|ADR|pref> — <one-line summary>"
+
+## Don't capture
+
+- Transient debug output, command results, or session-specific scratch
+- Anything the user explicitly says is one-off
+- Secrets, credentials, tokens — mindkeep is local plaintext SQLite
+"""
+
+COPILOT = """\
+# Project memory (mindkeep)
+
+This section instructs GitHub Copilot agents to use mindkeep as durable
+project memory across sessions.
+
+At the start of every session, if `mindkeep` is on PATH and the current working
+directory is **not** the user's home directory or a system temp dir, silently run:
+
+- `mindkeep show --kind facts`
+- `mindkeep show --kind adrs`
+- `mindkeep show --kind sessions --limit 3`
+
+Treat the output as authoritative project context for this session. Do not
+announce the lookup unless results are non-empty — if there are facts or ADRs,
+briefly summarize them as "🧠 mindkeep recall: …" so the user knows the
+context was loaded. If results are empty, stay silent.
+
+If `mindkeep` is not installed, skip silently.
+
+## Targeted lookup
+
+Before answering any non-trivial question about this project, run:
+
+- `mindkeep recall "<query>"` — full-text search across facts and ADRs.
+
+## When to write to mindkeep
+
+Capture durable signal proactively (don't wait for the user to ask):
+
+- **Facts** — non-obvious truths about this project worth remembering:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().add_fact('<content>', tags=['<tag>'])"
+  ```
+
+- **ADRs** — architectural decisions with rationale:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().add_adr(title='<title>', decision='<what>', rationale='<why>')"
+  ```
+
+- **Preferences** — user-scoped or project-scoped settings:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().set_preference('<key>', '<value>')"
+  ```
+
+Tell the user concisely when you've recorded something:
+"📝 Saved to mindkeep: <fact|ADR|pref> — <one-line summary>"
+
+## Don't capture
+
+- Transient debug output, command results, or session-specific scratch
+- Anything the user explicitly says is one-off
+- Secrets, credentials, tokens — mindkeep is local plaintext SQLite
+"""
+
+CURSOR = """\
+# Project memory (mindkeep)
+
+You are operating inside Cursor. Use mindkeep as durable project memory across
+sessions and chats.
+
+At the start of every chat or composer session, if `mindkeep` is on PATH and
+the workspace root is **not** the user's home directory or a system temp dir,
+silently run in the integrated terminal:
+
+- `mindkeep show --kind facts`
+- `mindkeep show --kind adrs`
+- `mindkeep show --kind sessions --limit 3`
+
+Treat the output as authoritative project context. Do not announce the lookup
+unless results are non-empty — if there are facts or ADRs, briefly summarize
+them as "🧠 mindkeep recall: …". If results are empty, stay silent.
+
+If `mindkeep` is not installed, skip silently.
+
+## Targeted lookup
+
+Before answering any non-trivial question about this project, run:
+
+- `mindkeep recall "<query>"` — full-text search across facts and ADRs.
+
+## When to write to mindkeep
+
+Capture durable signal proactively:
+
+- **Facts** — non-obvious project truths worth remembering:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().add_fact('<content>', tags=['<tag>'])"
+  ```
+
+- **ADRs** — architectural decisions with rationale:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().add_adr(title='<title>', decision='<what>', rationale='<why>')"
+  ```
+
+- **Preferences** — durable settings (style, tooling choices):
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().set_preference('<key>', '<value>')"
+  ```
+
+Tell the user concisely when you've recorded something:
+"📝 Saved to mindkeep: <fact|ADR|pref> — <one-line summary>"
+
+## Don't capture
+
+- Transient debug output, command results, or scratch
+- Anything explicitly one-off
+- Secrets — mindkeep is local plaintext SQLite
+"""
+
+GENERIC = """\
+# Project memory (mindkeep)
+
+These instructions are vendor-neutral and apply to any AI coding agent that
+can run shell commands and Python in the user's workspace.
+
+At the start of every session, if `mindkeep` is on PATH and the current working
+directory is **not** the user's home directory or a system temp dir, silently run:
+
+- `mindkeep show --kind facts`
+- `mindkeep show --kind adrs`
+- `mindkeep show --kind sessions --limit 3`
+
+Treat the output as authoritative project context. Do not announce the lookup
+unless results are non-empty — if there are facts or ADRs, briefly summarize
+them as "🧠 mindkeep recall: …" so the user knows the context was loaded. If
+results are empty, stay silent.
+
+If `mindkeep` is not installed, skip silently.
+
+## Targeted lookup
+
+Before answering any non-trivial question about this project, run:
+
+- `mindkeep recall "<query>"` — full-text search across facts and ADRs.
+
+## When to write to mindkeep
+
+Capture durable signal proactively (don't wait for the user to ask):
+
+- **Facts** — non-obvious project truths worth remembering across sessions:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().add_fact('<content>', tags=['<tag>'])"
+  ```
+
+- **ADRs** — architectural decisions with rationale:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().add_adr(title='<title>', decision='<what>', rationale='<why>')"
+  ```
+
+- **Preferences** — durable user/project settings:
+  ```
+  python -c "from mindkeep import MemoryStore; MemoryStore.open().set_preference('<key>', '<value>')"
+  ```
+
+Tell the user concisely when you've recorded something:
+"📝 Saved to mindkeep: <fact|ADR|pref> — <one-line summary>"
+
+## Don't capture
+
+- Transient debug output, command results, or session-specific scratch
+- Anything the user explicitly says is one-off
+- Secrets, credentials, tokens — mindkeep is local plaintext SQLite
+"""
+
+TARGETS: dict[str, str] = {
+    "claude": CLAUDE,
+    "copilot": COPILOT,
+    "cursor": CURSOR,
+    "generic": GENERIC,
+}
+
+
+def render(target: str) -> str:
+    """Return the snippet for *target*. Raises KeyError if unknown."""
+    return TARGETS[target]
+
+
+def supported() -> list[str]:
+    """Return the list of supported target names in stable order."""
+    return ["claude", "copilot", "cursor", "generic"]

--- a/src/mindkeep/cli.py
+++ b/src/mindkeep/cli.py
@@ -1245,6 +1245,40 @@ def _cmd_recall(data_dir: Path, args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_integrate(args: argparse.Namespace) -> int:
+    from . import _integrations
+
+    if getattr(args, "list", False):
+        for name in _integrations.supported():
+            print(name)
+        return 0
+
+    target = args.target
+    if target is None or target not in _integrations.TARGETS:
+        supported = ", ".join(_integrations.supported())
+        print(f"error: unknown target: {target!r}", file=sys.stderr)
+        print(f"supported targets: {supported}", file=sys.stderr)
+        return 2
+
+    snippet = _integrations.render(target)
+
+    out = getattr(args, "out", None)
+    if out:
+        out_path = Path(out)
+        if out_path.exists() and not getattr(args, "force", False):
+            print(
+                f"error: refusing to overwrite {out_path} (pass --force to overwrite)",
+                file=sys.stderr,
+            )
+            return 1
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(snippet, encoding="utf-8")
+        return 0
+
+    sys.stdout.write(snippet)
+    return 0
+
+
 def _cmd_stats(data_dir: Path, args: argparse.Namespace) -> int:
     """Print per-project store stats (human or JSON)."""
     ph = _resolve_project_hash(data_dir, args.project)
@@ -1457,6 +1491,29 @@ def _build_parser() -> argparse.ArgumentParser:
     pu.add_argument("--yes", "-y", action="store_true",
                     help="skip interactive confirmation")
 
+    pint = sub.add_parser(
+        "integrate",
+        help="emit an integration snippet for an AI coding agent "
+             "(claude|copilot|cursor|generic)",
+    )
+    pint.add_argument(
+        "target", nargs="?", default=None, metavar="<target>",
+        help="one of: claude, copilot, cursor, generic",
+    )
+    pint.add_argument(
+        "--list", action="store_true",
+        help="list supported targets and exit",
+    )
+    pint.add_argument(
+        "--out", default=None, metavar="PATH",
+        help="write the snippet to PATH instead of stdout "
+             "(creates parent dirs; refuses to overwrite without --force)",
+    )
+    pint.add_argument(
+        "--force", action="store_true",
+        help="overwrite --out PATH if it already exists",
+    )
+
     psess = sub.add_parser(
         "session",
         help="inspect or reset the per-shell token budget state",
@@ -1501,6 +1558,8 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_upgrade(args)
         if args.cmd == "session":
             return _cmd_session(args)
+        if args.cmd == "integrate":
+            return _cmd_integrate(args)
     except _ProjectNotFound as exc:
         # User asked for a project that doesn't exist → user error.
         print(f"error: {exc}", file=sys.stderr)

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -1,0 +1,106 @@
+"""Tests for `mindkeep integrate <target>` (P1-5, #10)."""
+
+from __future__ import annotations
+
+import io
+import re
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from mindkeep import _integrations
+from mindkeep.cli import main as cli_main
+
+
+TARGETS = ["claude", "copilot", "cursor", "generic"]
+TARGET_KEYWORDS = {
+    "claude": "Claude",
+    "copilot": "Copilot",
+    "cursor": "Cursor",
+    "generic": "vendor-neutral",
+}
+
+
+def _run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = cli_main(list(argv))
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_list_lists_four_targets() -> None:
+    rc, out, _ = _run("integrate", "--list")
+    assert rc == 0
+    listed = [ln.strip() for ln in out.strip().splitlines() if ln.strip()]
+    assert listed == TARGETS
+
+
+@pytest.mark.parametrize("target", TARGETS)
+def test_target_snippet_has_required_content(target: str) -> None:
+    rc, out, _ = _run("integrate", target)
+    assert rc == 0
+    assert TARGET_KEYWORDS[target].lower() in out.lower() or target.lower() in out.lower()
+    assert "mindkeep recall" in out
+    assert "mindkeep show" in out
+    assert ("add_fact" in out) or ("add_adr" in out)
+
+
+@pytest.mark.parametrize("target", TARGETS)
+def test_snippet_no_placeholders(target: str) -> None:
+    snippet = _integrations.render(target)
+    for bad in ("TODO", "PLACEHOLDER", "XXX", "FIXME"):
+        assert bad not in snippet, f"{target} snippet contains {bad}"
+
+
+@pytest.mark.parametrize("target", TARGETS)
+def test_snippet_valid_utf8(target: str) -> None:
+    snippet = _integrations.render(target)
+    encoded = snippet.encode("utf-8")
+    assert encoded.decode("utf-8") == snippet
+    # No surrogate code points.
+    assert not re.search(r"[\ud800-\udfff]", snippet)
+
+
+def test_unknown_target_exits_2() -> None:
+    rc, _, err = _run("integrate", "nonsuch")
+    assert rc == 2
+    assert "supported targets: claude, copilot, cursor, generic" in err
+
+
+def test_no_target_and_no_list_exits_2() -> None:
+    rc, _, err = _run("integrate")
+    assert rc == 2
+    assert "supported targets" in err
+
+
+def test_out_writes_file_with_same_content(tmp_path: Path) -> None:
+    target = "claude"
+    rc_stdout, stdout, _ = _run("integrate", target)
+    assert rc_stdout == 0
+
+    dest = tmp_path / "nested" / "claude.md"
+    rc, out, _ = _run("integrate", target, "--out", str(dest))
+    assert rc == 0
+    assert out == ""
+    assert dest.read_text(encoding="utf-8") == stdout
+
+
+def test_out_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    dest = tmp_path / "exists.md"
+    dest.write_text("OLD CONTENT", encoding="utf-8")
+
+    rc, _, err = _run("integrate", "generic", "--out", str(dest))
+    assert rc == 1
+    assert "refusing to overwrite" in err
+    assert dest.read_text(encoding="utf-8") == "OLD CONTENT"
+
+
+def test_out_force_overwrites(tmp_path: Path) -> None:
+    dest = tmp_path / "exists.md"
+    dest.write_text("OLD", encoding="utf-8")
+
+    rc, _, _ = _run("integrate", "generic", "--out", str(dest), "--force")
+    assert rc == 0
+    assert "OLD" not in dest.read_text(encoding="utf-8")
+    assert "mindkeep recall" in dest.read_text(encoding="utf-8")


### PR DESCRIPTION
Implements P1-5 from the v0.3.0 milestone.

Adds `mindkeep integrate <target>` which emits a ready-to-paste markdown snippet
for embedding mindkeep into popular AI coding agents' instruction files.

## Targets

- `claude` — for `~/.claude/claude.md` style
- `copilot` — for `~/.copilot/AGENTS.md` style
- `cursor` — for `.cursorrules` / `.cursor/rules` style
- `generic` — vendor-neutral plain markdown

## Flags

- `--list` — list supported targets, exit 0
- `--out PATH` — write snippet to file (creates parent dirs)
- `--force` — overwrite existing `--out` file
- Unknown target → exit 2 with `supported targets: claude, copilot, cursor, generic`

## Snippet contents

Each snippet instructs the agent to:
1. At session start (silently): `mindkeep show --kind facts|adrs|sessions --limit 3`
2. Use `mindkeep recall <query>` for targeted lookups
3. Capture durable signal proactively via the Python API (add_fact / add_adr / set_preference)
4. Skip silently if `mindkeep` is not on PATH
5. Tell user concisely when something is recorded

Templates live in `src/mindkeep/_integrations.py` as raw module-level strings
with no user-specific path interpolation, so they're safe to drop into any agent
instructions file.

## Tests

18 new tests in `tests/test_integrate.py` covering: list, per-target content,
placeholder hygiene, UTF-8 validity, unknown target, --out write, overwrite refusal,
and --force overwrite. Total: 270 passing.

Closes #10