### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ---
 
+## [0.3.0] - 2026-05-06
+
+Schema v3 + retrieval, capture, and observability layer.
+
+### Added
+
+- **Schema v3 + FTS5** (#6): `last_accessed_at`, `access_count`, `pin`, `archived_at`, `token_estimate` columns on facts/adrs; `facts_fts` and `adrs_fts` virtual tables with `unicode61 remove_diacritics 1` tokenizer (CJK-friendly).
+- **Session token budget** (#7): `MINDKEEP_SESSION_BUDGET=N` env var caps cumulative tokens emitted per parent process; `mindkeep session status|reset` CLI; per-pid state file under `$XDG_RUNTIME_DIR` / `%LOCALAPPDATA%`.
+- **`show --top K` / `show --budget N`** (#8): cap rendered rows by count or by cumulative token estimate; pinned rows always come first.
+- **`mindkeep recall <query>`** (#9): FTS5 + bm25 ranked search across facts and adrs. Flags: `--top K`, `--kind facts|adrs|all`, `--json`. Lower bm25 = better; uses `snippet()` for highlighting.
+- **`mindkeep stats [--json]`** (#11): per-store token totals, fact/adr counts, pin counts, oldest/newest entries.
+- **Dual-threshold write guard** (#12): caps facts at 100 tokens and adrs at 1500 tokens (env-overridable). Rejects oversize content unless `force=True`. Detects pre-redaction over-cap (2× heuristic) and warns when redaction shrinks input >50%.
+- **`mindkeep pin` / `mindkeep unpin`** (#13): mark facts/adrs as pinned so they survive token budgets and rank first in `show`. New API: `pin_fact`, `unpin_fact`, `pin_adr`, `unpin_adr`, plus `pinned_only=` filter on list APIs.
+- **`mindkeep doctor` enhancements** (#14): 8 health checks — schema-version up-to-date, WAL active, FTS5 integrity, store stats, token-cap pressure, stale entries, DB size + VACUUM hint, pin sanity. New `--json` mode.
+- **`mindkeep integrate <claude|copilot|cursor|generic>`** (#10): emits ready-to-paste integration snippets for popular AI coding agents. Flags: `--out PATH`, `--force`, `--list`.
+- **Eval harness** (#15): `python -m mindkeep.evals` runs 8 reproducible scenarios (recall@5, top-1 ordering, CJK recall, budget compliance, top compliance, pin priority, write-guard reject, doctor green) and emits a JSON report. Lives in `src/mindkeep/evals/`.
+
+### Fixed
+
+- **CI flakiness on first-open contention** (#18): `PRAGMA journal_mode=WAL` does not invoke busy_handler, causing immediate `SQLITE_BUSY` when multiple processes opened the DB concurrently. `Storage` now sets `busy_timeout=5000` before any contended pragma, skips the WAL switch when already on WAL, and wraps schema init / `migrate_to_v3` in `BEGIN IMMEDIATE` retries. CI: 6/6 green for the first time since v0.2.0.
+
+### Notes
+
+- 277-test suite covering all v0.3.0 features plus a regression baseline.
+- v0.3.0 is fully backwards-compatible with v0.2.0 stores; first open auto-migrates schema_version 2 → 3 in a single transaction.
+- Known follow-up tracked in #28: eval corpus is currently trivially separable; queries and thresholds will be tightened in v0.3.1.
+
+---
+
 ## [0.2.0] - 2026-04-27
 
 Initial public release of **mindkeep**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mindkeep"
-version = "0.2.0"
+version = "0.3.0"
 description = "Cross-project on-disk memory store for AI coding agents (stdlib-only, SQLite/WAL)."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps version 0.2.0 -> 0.3.0 and finalises CHANGELOG.

Milestone: https://github.com/AllenS0104/mindkeep/milestone/1

All 10 v0.3.0 issues (#6-#15) plus #18 CI fix are merged. 277 tests green on main.

After merge:
1. tag v0.3.0
2. python -m build && twine upload dist/*
3. close milestone v0.3.0

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>