### PR TITLE
mcp: project skeleton + entry points (#33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,31 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -v
+
+  mcp-extra:
+    name: mcp-extra (ubuntu-latest, py3.12, mcp 1.26)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install package with [mcp] extra and pinned tested SDK
+        # The [mcp] extra is `mcp>=1.0,<2.0`; we pin 1.26.0 here to
+        # match the version called out in DESIGN-v0.4.0 §7. Bumps are
+        # an intentional, reviewable change.
+        run: |
+          python -m pip install -e ".[dev,mcp]"
+          python -m pip install "mcp==1.26.0"
+
+      - name: Run tests including stdio round-trip
+        env:
+          MINDKEEP_MCP_STDIO_E2E: "1"
+        run: pytest tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,15 @@ dev = [
     "pytest>=7.4",
     "pytest-cov>=4.1",
 ]
+# Optional MCP server support. Pinned per DESIGN-v0.4.0 §7: tested
+# against mcp 1.26.0; <2.0 protects v0.4 from a future breaking-major.
+mcp = [
+    "mcp>=1.0,<2.0",
+]
 
 [project.scripts]
 mindkeep = "mindkeep.cli:main"
+mindkeep-mcp = "mindkeep.mcp.server:main"
 
 [project.urls]
 Homepage = "https://github.com/AllenS0104/mindkeep"

--- a/src/mindkeep/cli.py
+++ b/src/mindkeep/cli.py
@@ -1372,6 +1372,31 @@ def _cmd_stats(data_dir: Path, args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_mcp(args: argparse.Namespace) -> int:
+    """Dispatch ``mindkeep mcp <subcommand>``.
+
+    ``mindkeep.mcp.server`` is imported here, on first dispatch, so
+    that argparse parser construction (and ``mindkeep --help``) never
+    pulls in ``mindkeep.mcp.*`` — keeping the lazy-import contract in
+    DESIGN-v0.4.0 §7.1 honored. ``mindkeep.mcp.server`` itself only
+    imports the ``mcp`` SDK lazily inside its own ``main()``.
+    """
+    if args.mcp_cmd == "serve":
+        from .mcp.server import main as _serve_main
+
+        forwarded: list[str] = []
+        if args.project_dir:
+            forwarded += ["--project-dir", args.project_dir]
+        if args.read_only:
+            forwarded.append("--read-only")
+        if args.allow_writes:
+            forwarded.append("--allow-writes")
+        return _serve_main(forwarded)
+    # Unreachable: subparsers is required=True.
+    print("error: missing mcp subcommand", file=sys.stderr)  # pragma: no cover
+    return 2  # pragma: no cover
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="mindkeep",
@@ -1514,6 +1539,37 @@ def _build_parser() -> argparse.ArgumentParser:
         help="overwrite --out PATH if it already exists",
     )
 
+    # ``mcp`` subcommand. Parser construction MUST stay free of any
+    # ``mcp`` SDK imports — DESIGN-v0.4.0 §7.1 hard requirement. The
+    # SDK is only imported lazily inside ``mindkeep.mcp.server.main``
+    # when this subcommand is actually dispatched.
+    pmcp = sub.add_parser("mcp", help="MCP server commands (v0.4.0+)")
+    pmcp_sub = pmcp.add_subparsers(
+        dest="mcp_cmd", metavar="<subcommand>", required=True,
+    )
+    pmcp_serve = pmcp_sub.add_parser(
+        "serve",
+        help="run the mindkeep MCP server over stdio",
+        description=(
+            "Run the mindkeep MCP server over stdio. Requires the "
+            "[mcp] extra: pip install 'mindkeep[mcp]'."
+        ),
+    )
+    pmcp_serve.add_argument(
+        "--project-dir", default=None, metavar="PATH",
+        help="bind the server to PATH "
+             "(overrides MINDKEEP_PROJECT_DIR and cwd discovery)",
+    )
+    pmcp_g = pmcp_serve.add_mutually_exclusive_group()
+    pmcp_g.add_argument(
+        "--read-only", action="store_true",
+        help="explicit read-only mode (default; alias / no-op for now)",
+    )
+    pmcp_g.add_argument(
+        "--allow-writes", action="store_true",
+        help="enable write tools (off by default; wired up in #35)",
+    )
+
     psess = sub.add_parser(
         "session",
         help="inspect or reset the per-shell token budget state",
@@ -1560,6 +1616,8 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_session(args)
         if args.cmd == "integrate":
             return _cmd_integrate(args)
+        if args.cmd == "mcp":
+            return _cmd_mcp(args)
     except _ProjectNotFound as exc:
         # User asked for a project that doesn't exist → user error.
         print(f"error: {exc}", file=sys.stderr)

--- a/src/mindkeep/mcp/__init__.py
+++ b/src/mindkeep/mcp/__init__.py
@@ -1,0 +1,13 @@
+"""mindkeep MCP server package.
+
+This subpackage is the v0.4 MCP integration for mindkeep. It is *only*
+imported when the user explicitly runs the ``mindkeep mcp serve``
+subcommand or the ``mindkeep-mcp`` console script. The MCP SDK itself
+lives behind the ``[mcp]`` optional-dependency extra and is imported
+lazily inside :func:`mindkeep.mcp.server.main` — see DESIGN-v0.4.0 §7.1.
+
+Importing this package MUST NOT pull in the ``mcp`` SDK; that invariant
+is asserted by ``tests/test_mcp_skeleton.py``.
+"""
+
+__all__: list[str] = []

--- a/src/mindkeep/mcp/server.py
+++ b/src/mindkeep/mcp/server.py
@@ -1,0 +1,218 @@
+"""mindkeep MCP server entry point (skeleton).
+
+================================================================
+STDIO INVARIANT  (DESIGN-v0.4.0 §3.4)
+----------------------------------------------------------------
+In stdio MCP transport, **stdout is the JSON-RPC frame channel**.
+ANY ``print()``, banner, log line, or ``traceback.print_exc()``
+written to stdout will corrupt the protocol stream and brick the
+session. All diagnostics in this module — and any code reachable
+from a tool handler — MUST go to ``sys.stderr``.
+
+This file deliberately uses ``sys.stderr.write(...)`` everywhere
+and never touches ``sys.stdout``. Future contributors: keep it
+that way.
+================================================================
+
+Lazy-import contract (DESIGN-v0.4.0 §7.1): importing this module
+must not pull in the ``mcp`` SDK. The SDK is imported inside
+:func:`main` so that ``mindkeep --help`` and ``import mindkeep``
+keep working without the ``[mcp]`` extra installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from ..memory_api import MemoryStore
+
+__all__ = ["main", "build_parser"]
+
+
+# Single source of truth for the missing-extra hint. Both entry points
+# (``mindkeep mcp serve`` and ``mindkeep-mcp``) end up here, so this
+# message is what users see when they forgot ``pip install
+# 'mindkeep[mcp]'``.
+_INSTALL_HINT = (
+    "mindkeep: MCP support requires the \"mcp\" extra. "
+    "Install with: pip install 'mindkeep[mcp]'\n"
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``mindkeep-mcp`` argparse parser.
+
+    Kept free of any ``mcp`` SDK imports so the parser can be
+    constructed (and ``--help`` rendered) in environments without the
+    optional extra installed.
+    """
+    p = argparse.ArgumentParser(
+        prog="mindkeep-mcp",
+        description="Run the mindkeep MCP server over stdio.",
+    )
+    p.add_argument(
+        "--project-dir",
+        default=None,
+        metavar="PATH",
+        help=(
+            "bind the server to PATH (overrides MINDKEEP_PROJECT_DIR "
+            "and cwd discovery; see DESIGN-v0.4.0 §8.1)"
+        ),
+    )
+    g = p.add_mutually_exclusive_group()
+    g.add_argument(
+        "--read-only",
+        action="store_true",
+        help=(
+            "explicit read-only mode (default; alias / no-op for now — "
+            "write tools land in #35)"
+        ),
+    )
+    g.add_argument(
+        "--allow-writes",
+        action="store_true",
+        help=(
+            "enable write tools (off by default; ignored in skeleton, "
+            "wired up in #35)"
+        ),
+    )
+    return p
+
+
+def _resolve_project_dir(args: argparse.Namespace) -> Tuple[Path, str]:
+    """Return ``(resolved_path, id_source)`` per DESIGN §8.1.
+
+    Precedence: ``--project-dir`` > ``MINDKEEP_PROJECT_DIR`` env >
+    ``Path.cwd()``. Relative paths resolve against the server's
+    startup cwd. Never raises.
+    """
+    raw = getattr(args, "project_dir", None)
+    if raw:
+        return Path(raw).expanduser().resolve(), "flag"
+    env = os.environ.get("MINDKEEP_PROJECT_DIR")
+    if env:
+        return Path(env).expanduser().resolve(), "env"
+    return Path.cwd().resolve(), "cwd-discovery"
+
+
+def _is_temp_dir(path: Path) -> bool:
+    """True iff ``path`` is the OS temp dir or lives beneath it."""
+    try:
+        tmp = Path(tempfile.gettempdir()).resolve()
+    except OSError:  # pragma: no cover - defensive
+        return False
+    try:
+        path.relative_to(tmp)
+        return True
+    except ValueError:
+        return False
+
+
+def _has_project_marker(path: Path) -> bool:
+    """True iff ``path`` or any ancestor has a ``.git`` or ``.mindkeep``."""
+    for candidate in (path, *path.parents):
+        if (candidate / ".git").exists() or (candidate / ".mindkeep").exists():
+            return True
+    return False
+
+
+def _emit_startup_diagnostic(path: Path, id_source: str) -> None:
+    """Per DESIGN §8.4: warn to stderr if the resolved dir looks bogus.
+
+    The warning is informational — the server still starts. The point
+    is to make "agent silently bound to my home dir" diagnosable
+    instead of invisible.
+    """
+    home: Optional[Path]
+    try:
+        home = Path.home().resolve()
+    except RuntimeError:  # pragma: no cover - HOME may be unset on weird systems
+        home = None
+
+    reason: Optional[str] = None
+    if home is not None and path == home:
+        reason = "user home directory"
+    elif _is_temp_dir(path):
+        reason = "OS temp directory"
+    elif not _has_project_marker(path):
+        reason = "no .git or .mindkeep marker found"
+
+    if reason is not None:
+        sys.stderr.write(
+            f"mindkeep-mcp: warning: resolved project dir {path} looks "
+            f"like {reason}; agent reads/writes may go to an "
+            f"unexpected store. (id_source={id_source})\n"
+        )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point for ``mindkeep-mcp`` and ``mindkeep mcp serve``.
+
+    Skeleton lifecycle (#33): parse args → resolve project dir →
+    optional stderr warning → lazy-import ``mcp`` SDK → open
+    :class:`MemoryStore` → run an empty-tool stdio server → close
+    on shutdown. Tool handlers are added in #34/#35.
+    """
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    project_dir, id_source = _resolve_project_dir(args)
+    _emit_startup_diagnostic(project_dir, id_source)
+
+    # Lazy SDK import — DESIGN §7.1 hard requirement. Catching
+    # ``ImportError`` (parent of ``ModuleNotFoundError``) covers the
+    # case where ``mcp`` is installed but partially broken.
+    try:
+        from mcp.server import Server  # type: ignore[import-not-found]
+        from mcp.server.stdio import stdio_server  # type: ignore[import-not-found]
+    except ImportError:
+        sys.stderr.write(_INSTALL_HINT)
+        return 2
+
+    # Surface the resolution to stderr so hosts (and humans tailing
+    # logs) can diagnose "wait, why is the agent reading the wrong
+    # project". Mirrors the data the ``mindkeep://project`` resource
+    # will expose in #34 (DESIGN §8.3).
+    sys.stderr.write(
+        f"mindkeep-mcp: project_dir={project_dir} id_source={id_source}\n"
+    )
+
+    # Local imports to keep module-load time minimal and to keep this
+    # block out of the ``--help`` path.
+    import asyncio
+
+    from .tools import TOOLS
+
+    store = MemoryStore.open(cwd=project_dir)
+    try:
+        srv = Server("mindkeep")
+
+        @srv.list_tools()  # type: ignore[misc]
+        async def _list_tools():  # noqa: D401 - SDK callback shape
+            # #33 ships an empty registry; #34/#35 will populate it.
+            return list(TOOLS)
+
+        async def _run() -> None:
+            async with stdio_server() as (read_stream, write_stream):
+                await srv.run(
+                    read_stream,
+                    write_stream,
+                    srv.create_initialization_options(),
+                )
+
+        try:
+            asyncio.run(_run())
+        except KeyboardInterrupt:  # pragma: no cover - signal path
+            pass
+    finally:
+        store.close()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/mindkeep/mcp/tools.py
+++ b/src/mindkeep/mcp/tools.py
@@ -1,0 +1,37 @@
+"""MCP tool registry.
+
+Skeleton-only in this ticket (#33). The actual tool handlers
+(``recall``, ``list_facts``, ``add_fact``, ...) are filled in by #34
+(read tools) and #35 (write tools).
+
+The registry is intentionally tiny: a list of registered tool
+descriptors, plus a :func:`register` decorator subsequent tickets can
+hang their handlers off of without further plumbing changes here.
+
+This module MUST NOT import the ``mcp`` SDK at top level — it is
+imported by :mod:`mindkeep.mcp.server`, which itself must remain
+SDK-free until ``main()`` is called (see DESIGN-v0.4.0 §7.1).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List
+
+# List of registered tool descriptors. Each entry's concrete shape is
+# defined by #34/#35; for the skeleton we only need it to exist and be
+# empty so ``tools/list`` returns ``[]``.
+TOOLS: List[Any] = []
+
+
+def register(handler: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator that appends ``handler`` to :data:`TOOLS`.
+
+    Stored as-is; #34/#35 decide the descriptor shape. The decorator
+    is identity-preserving so handlers remain importable and testable
+    on their own.
+    """
+    TOOLS.append(handler)
+    return handler
+
+
+__all__ = ["TOOLS", "register"]

--- a/tests/test_mcp_skeleton.py
+++ b/tests/test_mcp_skeleton.py
@@ -1,0 +1,336 @@
+"""Skeleton-level tests for the ``mindkeep.mcp`` subpackage (issue #33).
+
+These guard the lazy-import contract (DESIGN-v0.4.0 §7.1), the project
+resolution precedence (§8), the missing-extra friendly error, the
+read-only / allow-writes mutex, and the startup-time diagnostic warning
+(§8.4). Tool-handler behavior lands in #34/#35 — not covered here.
+"""
+
+from __future__ import annotations
+
+import builtins
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------- helpers
+
+# Code that, when prepended to a child Python's ``-c`` script, makes any
+# ``import mcp`` (or ``from mcp...``) raise ``ModuleNotFoundError`` —
+# simulating a venv where the user installed plain ``mindkeep`` without
+# the ``[mcp]`` extra.
+_BLOCK_MCP_PRELUDE = (
+    "import builtins, sys\n"
+    "_real_import = builtins.__import__\n"
+    "def _fake_import(name, globals_=None, locals_=None, fromlist=(), level=0):\n"
+    "    # Only block absolute imports of the SDK; relative imports\n"
+    "    # like `from .mcp.server import main` (level>=1) must pass\n"
+    "    # through so the mindkeep.mcp subpackage stays loadable.\n"
+    "    if level == 0 and (name == 'mcp' or name.startswith('mcp.')):\n"
+    "        raise ModuleNotFoundError(\"No module named 'mcp'\")\n"
+    "    return _real_import(name, globals_, locals_, fromlist, level)\n"
+    "for _k in list(sys.modules):\n"
+    "    if _k == 'mcp' or _k.startswith('mcp.'):\n"
+    "        sys.modules.pop(_k, None)\n"
+    "builtins.__import__ = _fake_import\n"
+)
+
+
+def _run_child(script: str) -> subprocess.CompletedProcess:
+    """Run ``script`` in a fresh Python child and return the result."""
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def block_mcp_import(monkeypatch: pytest.MonkeyPatch):
+    """In-process equivalent of ``_BLOCK_MCP_PRELUDE``.
+
+    Pops any cached ``mcp`` modules and patches ``builtins.__import__``
+    so subsequent ``import mcp`` / ``from mcp...`` calls raise
+    ``ModuleNotFoundError``. Reverted on teardown.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, globals_=None, locals_=None, fromlist=(), level=0):
+        # Only block absolute imports of the SDK; relative imports
+        # like ``from .mcp.server import main`` (level>=1) must pass
+        # through so the ``mindkeep.mcp`` subpackage stays loadable.
+        if level == 0 and (name == "mcp" or name.startswith("mcp.")):
+            raise ModuleNotFoundError(f"No module named {name!r}")
+        return real_import(name, globals_, locals_, fromlist, level)
+
+    for k in list(sys.modules):
+        if k == "mcp" or k.startswith("mcp."):
+            monkeypatch.delitem(sys.modules, k, raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+# ---------------------------------------------------- lazy-import contract
+
+def test_import_mindkeep_without_mcp_extra() -> None:
+    """``import mindkeep`` must not pull in the ``mcp`` SDK."""
+    script = (
+        _BLOCK_MCP_PRELUDE
+        + "import mindkeep\n"
+        + "import mindkeep.cli\n"
+        + "assert 'mcp' not in sys.modules, sorted(sys.modules)\n"
+        + "assert not any(k.startswith('mcp.') for k in sys.modules)\n"
+    )
+    r = _run_child(script)
+    assert r.returncode == 0, r.stderr
+
+
+def test_cli_help_without_mcp_extra() -> None:
+    """``mindkeep --help`` must work and mention ``mcp`` w/o SDK import."""
+    script = (
+        _BLOCK_MCP_PRELUDE
+        + "from mindkeep.cli import _build_parser\n"
+        + "p = _build_parser()\n"
+        + "h = p.format_help()\n"
+        + "assert 'mcp' in h, h\n"
+        + "assert 'mcp' not in sys.modules, sorted(sys.modules)\n"
+        + "assert not any(k.startswith('mcp.') for k in sys.modules)\n"
+    )
+    r = _run_child(script)
+    assert r.returncode == 0, r.stderr
+
+
+# ---------------------------------------------- missing-extra friendly exit
+
+_EXPECTED_HINT = "pip install 'mindkeep[mcp]'"
+
+
+def test_mindkeep_mcp_serve_without_extra_exits_2(
+    block_mcp_import: None,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``mindkeep mcp serve`` exits 2 with the install hint when SDK absent."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MINDKEEP_PROJECT_DIR", raising=False)
+    # Ensure cli + mcp.server modules get re-imported with the import
+    # block in place (they may already be cached from earlier tests).
+    for k in [
+        "mindkeep.cli",
+        "mindkeep.mcp",
+        "mindkeep.mcp.server",
+        "mindkeep.mcp.tools",
+    ]:
+        monkeypatch.delitem(sys.modules, k, raising=False)
+
+    from mindkeep.cli import main as cli_main
+
+    rc = cli_main(["mcp", "serve"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert _EXPECTED_HINT in err
+
+
+def test_mindkeep_mcp_console_script_without_extra_exits_2(
+    tmp_path: Path,
+) -> None:
+    """The ``mindkeep-mcp`` console script entry exits 2 with the hint."""
+    script = (
+        _BLOCK_MCP_PRELUDE
+        + f"import os; os.chdir({str(tmp_path)!r})\n"
+        + "os.environ.pop('MINDKEEP_PROJECT_DIR', None)\n"
+        + "from mindkeep.mcp.server import main\n"
+        + "sys.exit(main([]))\n"
+    )
+    r = _run_child(script)
+    assert r.returncode == 2, (r.stdout, r.stderr)
+    assert _EXPECTED_HINT in r.stderr
+
+
+# ------------------------------------------------------------------ mutex
+
+def test_mutex_read_only_and_allow_writes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--read-only`` and ``--allow-writes`` together → exit 2."""
+    from mindkeep.mcp.server import main
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--read-only", "--allow-writes"])
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    # argparse names both flags in its mutex error message.
+    assert "--allow-writes" in err or "--read-only" in err
+
+
+# ------------------------------------------------- project resolution (§8)
+
+def test_project_dir_flag_overrides_env_and_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    c = tmp_path / "c"
+    for d in (a, b, c):
+        d.mkdir()
+    monkeypatch.chdir(c)
+    monkeypatch.setenv("MINDKEEP_PROJECT_DIR", str(b))
+
+    from mindkeep.mcp.server import _resolve_project_dir, build_parser
+
+    args = build_parser().parse_args(["--project-dir", str(a)])
+    path, source = _resolve_project_dir(args)
+    assert path == a.resolve()
+    assert source == "flag"
+
+
+def test_project_dir_env_used_when_no_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    b = tmp_path / "b"
+    c = tmp_path / "c"
+    for d in (b, c):
+        d.mkdir()
+    monkeypatch.chdir(c)
+    monkeypatch.setenv("MINDKEEP_PROJECT_DIR", str(b))
+
+    from mindkeep.mcp.server import _resolve_project_dir, build_parser
+
+    args = build_parser().parse_args([])
+    path, source = _resolve_project_dir(args)
+    assert path == b.resolve()
+    assert source == "env"
+
+
+def test_project_dir_falls_back_to_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    c = tmp_path / "c"
+    c.mkdir()
+    monkeypatch.chdir(c)
+    monkeypatch.delenv("MINDKEEP_PROJECT_DIR", raising=False)
+
+    from mindkeep.mcp.server import _resolve_project_dir, build_parser
+
+    args = build_parser().parse_args([])
+    path, source = _resolve_project_dir(args)
+    assert path == c.resolve()
+    assert source == "cwd-discovery"
+
+
+# ------------------------------------------ startup-time diagnostic (§8.4)
+
+def test_temp_cwd_emits_stderr_warning(
+    block_mcp_import: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Launching with cwd inside the OS temp dir emits a stderr warning.
+
+    pytest's ``tmp_path`` lives under ``tempfile.gettempdir()`` on every
+    supported platform, so the temp-dir branch of the diagnostic guard
+    fires.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MINDKEEP_PROJECT_DIR", raising=False)
+    for k in ["mindkeep.mcp", "mindkeep.mcp.server", "mindkeep.mcp.tools"]:
+        monkeypatch.delitem(sys.modules, k, raising=False)
+
+    from mindkeep.mcp.server import main
+
+    # Will exit 2 because the SDK import is blocked, but the
+    # diagnostic warning runs first.
+    rc = main([])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "warning" in err.lower()
+    assert "OS temp directory" in err or "no .git" in err
+
+
+def test_no_warning_for_real_project_dir(
+    block_mcp_import: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A dir with a ``.mindkeep`` marker should NOT trigger the warning.
+
+    Because pytest's tmp_path lives under the OS temp dir, the temp
+    branch fires unconditionally — so we instead verify the helper
+    directly to keep the assertion crisp.
+    """
+    project = tmp_path / "real-project"
+    project.mkdir()
+    (project / ".mindkeep").mkdir()  # marker present
+
+    from mindkeep.mcp.server import _has_project_marker, _is_temp_dir
+
+    # Marker found → no warning would fire on the marker branch.
+    assert _has_project_marker(project) is True
+    # ...but tmp_path is itself under the OS temp dir, sanity check:
+    assert _is_temp_dir(project) is True
+
+
+# ------------------------------------------------------ tools registry
+
+def test_tools_registry_is_empty_skeleton() -> None:
+    """``TOOLS`` ships empty in #33; ``register`` populates it for #34/#35."""
+    from mindkeep.mcp import tools
+
+    # Snapshot then restore so this test is order-independent.
+    saved = list(tools.TOOLS)
+    tools.TOOLS.clear()
+    try:
+        assert tools.TOOLS == []
+
+        @tools.register
+        def _example():  # pragma: no cover - trivial sentinel
+            return None
+
+        assert _example in tools.TOOLS
+    finally:
+        tools.TOOLS.clear()
+        tools.TOOLS.extend(saved)
+
+
+# --------------------------- optional: real stdio round-trip (gated)
+
+@pytest.mark.skipif(
+    os.environ.get("MINDKEEP_MCP_STDIO_E2E") != "1",
+    reason="round-trip e2e requires the [mcp] extra and is opt-in via env",
+)
+def test_tools_list_returns_empty_over_stdio(tmp_path: Path) -> None:
+    """End-to-end smoke: spawn the server, list tools, expect ``[]``.
+
+    Gated behind ``MINDKEEP_MCP_STDIO_E2E=1`` (set by the optional CI
+    job that installs ``mindkeep[mcp]``) so the core matrix never
+    requires the SDK. Imports the SDK lazily.
+    """
+    pytest.importorskip("mcp")
+    import asyncio
+
+    from mcp import ClientSession  # type: ignore[import-not-found]
+    from mcp.client.stdio import (  # type: ignore[import-not-found]
+        StdioServerParameters,
+        stdio_client,
+    )
+
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "mindkeep.mcp.server", "--project-dir", str(tmp_path)],
+    )
+
+    async def _go() -> list:
+        async with stdio_client(params) as (r, w):
+            async with ClientSession(r, w) as session:
+                await session.initialize()
+                result = await session.list_tools()
+                return list(result.tools)
+
+    tools = asyncio.run(_go())
+    assert tools == []


### PR DESCRIPTION
Closes #33.

## Acceptance criteria → verification

| Criterion | How verified |
| --- | --- |
| `src/mindkeep/mcp/{__init__,server,tools}.py` package | New files; `tools.TOOLS = []` + `register` decorator stub. |
| `mindkeep mcp serve` subcommand | Added to `src/mindkeep/cli.py`. |
| `mindkeep-mcp` console script | Added under `[project.scripts]` in `pyproject.toml`. |
| `[project.optional-dependencies] mcp = ["mcp>=1.0,<2.0"]` | Added in `pyproject.toml` (pin per DESIGN §7). |
| `import mindkeep` works without `[mcp]` extra | `test_import_mindkeep_without_mcp_extra` (subprocess + `__import__` block). |
| `mindkeep --help` works without extra and mentions `mcp` | `test_cli_help_without_mcp_extra`. |
| `mindkeep mcp serve` exits 2 with `pip install 'mindkeep[mcp]'` hint when SDK absent | `test_mindkeep_mcp_serve_without_extra_exits_2`. |
| `mindkeep-mcp` exits 2 with same hint | `test_mindkeep_mcp_console_script_without_extra_exits_2`. |
| `--read-only` / `--allow-writes` mutex | `test_mutex_read_only_and_allow_writes` (argparse mutex → exit 2). |
| `--project-dir` > `MINDKEEP_PROJECT_DIR` > cwd | `test_project_dir_flag_overrides_env_and_cwd`, `test_project_dir_env_used_when_no_flag`, `test_project_dir_falls_back_to_cwd`. |
| Resolved path passed as `cwd=` to `MemoryStore.open` (no new core code path) | Single call site in `server.main`; no edits to `memory_api.py` / `storage.py` / `project_id.py`. |
| Startup-time stderr warning for `$HOME`, OS temp dir, markerless cwd (DESIGN §8.4) | `test_temp_cwd_emits_stderr_warning` + `test_no_warning_for_real_project_dir` for the helper. |
| Lazy SDK import inside `main()` only (DESIGN §7.1) | `test_import_mindkeep_without_mcp_extra` asserts `'mcp' not in sys.modules` after importing `mindkeep` and `mindkeep.cli`. |
| Stdio invariant: no `print()` to stdout in MCP code paths | Header block + comments in `server.py`; only `sys.stderr.write` used. |
| `tools/list` returns `[]` over stdio | `test_tools_list_returns_empty_over_stdio` (gated by `MINDKEEP_MCP_STDIO_E2E=1`); the new `mcp-extra` CI job sets that env and runs it. |

## Test-suite delta

- Baseline on `main`: **278 passed**.
- This branch: **289 passed, 1 skipped** (the stdio e2e is opt-in via env).
- The new optional `mcp-extra` CI job (ubuntu / py3.12, installs `mindkeep[mcp]` and pins `mcp==1.26.0`) sets `MINDKEEP_MCP_STDIO_E2E=1`, so the e2e runs there.

## Deferred to #34/#35 (out of scope here)

- Concrete tool handlers (`recall`, `list_facts`, `add_fact`, …) and their schemas / descriptions.
- The `mindkeep://project` resource and other resources (DESIGN §4, §8.3).
- Read-only mode actually filtering write tools out of `tools/list`. `--read-only` is currently a no-op alias as the design specifies, since there are no write tools yet.
- `mindkeep.core.collect_stats` / `collect_doctor` extraction (DESIGN §3.3, scoped to #34).
- README / CHANGELOG updates (#40).

## Notes / minor deviations

- **CI**: I added a small `mcp-extra` job rather than skipping it. It only adds one job (ubuntu/py3.12) and runs the gated e2e — net cost is small and it directly verifies the round-trip the design's §14.1 calls out.
- **`build_parser`** in `mindkeep.mcp.server` is exported (not `_build_parser`) so tests can import it cleanly. Internal helpers stay underscore-prefixed.
- **Diagnostic warning** also fires for "no `.git`/`.mindkeep` ancestor" cwds, matching DESIGN §8.4 bullet 3 — not just home/temp. The test confirms one of these substrings appears.
