### PR TITLE
mcp: write tools (#34)

### DIFF
--- a/src/mindkeep/mcp/server.py
+++ b/src/mindkeep/mcp/server.py
@@ -77,8 +77,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--allow-writes",
         action="store_true",
         help=(
-            "enable write tools (off by default; ignored in skeleton, "
-            "wired up in #35)"
+            "enable write tools (off by default — see DESIGN-v0.4.0 §9). "
+            "Without this flag, mindkeep_add_fact / mindkeep_add_adr are "
+            "not registered and do not appear in tools/list."
         ),
     )
     return p
@@ -170,6 +171,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     try:
         from mcp.server import Server  # type: ignore[import-not-found]
         from mcp.server.stdio import stdio_server  # type: ignore[import-not-found]
+        from mcp.shared.exceptions import McpError  # type: ignore[import-not-found]
+        from mcp.types import (  # type: ignore[import-not-found]
+            CallToolRequest,
+            ErrorData,
+            METHOD_NOT_FOUND,
+            ServerResult,
+        )
     except ImportError:
         sys.stderr.write(_INSTALL_HINT)
         return 2
@@ -179,23 +187,97 @@ def main(argv: Optional[List[str]] = None) -> int:
     # project". Mirrors the data the ``mindkeep://project`` resource
     # will expose in #34 (DESIGN §8.3).
     sys.stderr.write(
-        f"mindkeep-mcp: project_dir={project_dir} id_source={id_source}\n"
+        f"mindkeep-mcp: project_dir={project_dir} id_source={id_source} "
+        f"allow_writes={bool(args.allow_writes)}\n"
     )
 
     # Local imports to keep module-load time minimal and to keep this
     # block out of the ``--help`` path.
     import asyncio
 
+    import jsonschema  # type: ignore[import-not-found]
+
     from .tools import TOOLS
+    from .tools_write import build_write_tools, make_internal_error, make_tool_error
 
     store = MemoryStore.open(cwd=project_dir)
     try:
         srv = Server("mindkeep")
 
+        # Build the registry. Read tools (#35) will hang off this same
+        # composition point. Write tools register only when the server
+        # was started with ``--allow-writes`` (DESIGN §9.1) — without
+        # the flag they are not announced in ``tools/list`` at all, so
+        # the model literally cannot try to call them.
+        all_tools = list(TOOLS)
+        all_handlers: dict = {}
+        if args.allow_writes:
+            wtools, whandlers = build_write_tools()
+            all_tools.extend(wtools)
+            all_handlers.update(whandlers)
+
         @srv.list_tools()  # type: ignore[misc]
         async def _list_tools():  # noqa: D401 - SDK callback shape
-            # #33 ships an empty registry; #34/#35 will populate it.
-            return list(TOOLS)
+            return list(all_tools)
+
+        # We install a custom ``CallToolRequest`` handler directly
+        # rather than using ``@srv.call_tool()`` because the SDK's
+        # decorator catches *every* ``Exception`` and converts it to a
+        # tool-result error. DESIGN §10.2 requires unhandled exceptions
+        # to surface as JSON-RPC -32603 with the traceback going to
+        # stderr only — ``McpError`` is the SDK's escape hatch for that
+        # path (re-raised by ``Server._handle_request``).
+        async def _call_tool_handler(req):  # type: ignore[no-untyped-def]
+            name = req.params.name
+            arguments = req.params.arguments or {}
+            handler = all_handlers.get(name)
+            if handler is None:
+                # Method-not-found at the protocol layer — the model
+                # asked for a tool we did not register. Standard
+                # JSON-RPC -32601.
+                raise McpError(
+                    ErrorData(
+                        code=METHOD_NOT_FOUND,
+                        message=f"Unknown tool: {name}",
+                    )
+                )
+
+            tool_def = next((t for t in all_tools if t.name == name), None)
+            if tool_def is not None:
+                try:
+                    jsonschema.validate(
+                        instance=arguments, schema=tool_def.inputSchema
+                    )
+                except jsonschema.ValidationError as exc:
+                    # Schema validation failure: §10 invalid_argument,
+                    # surfaced as a tool-result error so the model can
+                    # recover (edit the call and retry).
+                    return ServerResult(
+                        make_tool_error(
+                            "invalid_argument",
+                            exc.message,
+                            {
+                                "field": ".".join(str(p) for p in exc.absolute_path),
+                                "value": exc.instance,
+                                "reason": exc.message,
+                            },
+                        )
+                    )
+
+            try:
+                result = await handler(store, arguments)
+            except McpError:
+                raise
+            except Exception as exc:  # pragma: no cover - defensive
+                # ``make_internal_error`` writes the full traceback to
+                # stderr (NEVER stdout — see DESIGN §3.4) and returns a
+                # fresh ``McpError(ErrorData(code=-32603, ...))`` whose
+                # message contains only the exception class name.
+                raise make_internal_error(exc) from None
+
+            return ServerResult(result)
+
+        srv.request_handlers[CallToolRequest] = _call_tool_handler
 
         async def _run() -> None:
             async with stdio_server() as (read_stream, write_stream):

--- a/src/mindkeep/mcp/tools_write.py
+++ b/src/mindkeep/mcp/tools_write.py
@@ -1,0 +1,425 @@
+"""MCP write-tool handlers for ``mindkeep_add_fact`` / ``mindkeep_add_adr``.
+
+This module is the v0.4 boundary between the model-facing MCP tool
+schema and the underlying :class:`mindkeep.memory_api.MemoryStore` API.
+It owns:
+
+* Field renames (tool ``value`` ↔ ``MemoryStore.add_fact(content=...)``).
+* Return-shape backfill (the API returns ``int``; the tool returns
+  ``{id, token_estimate, pinned, ...}``).
+* Server-side dedup (DESIGN-v0.4.0 §9.3).
+* Error mapping for ``WriteGuardError`` / ``ValueError`` / ``StorageError``
+  / unhandled exceptions (DESIGN-v0.4.0 §10).
+
+The ``mcp`` SDK is imported **lazily** inside the helpers so that the
+module can be imported without the optional extra installed
+(DESIGN-v0.4.0 §7.1). ``MemoryStore`` and ``Storage`` exceptions are safe
+to import at module load — they live in core mindkeep.
+
+DESIGN-v0.4.0 §9 explicitly *removes* ``mindkeep_set_preference`` from
+the v0.4 MCP surface: preferences persist to a global, cross-project DB
+that an autonomous agent could poison permanently. v0.5 may revisit a
+project-scoped preference write tool. Do not add it here.
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Tuple
+
+from ..memory_api import MemoryStore, _tags_to_str
+from ..storage import StorageError, WriteGuardError
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from mcp.types import CallToolResult, Tool
+
+
+__all__ = [
+    "ADD_FACT_NAME",
+    "ADD_ADR_NAME",
+    "build_write_tools",
+    "make_tool_error",
+    "make_internal_error",
+]
+
+
+ADD_FACT_NAME = "mindkeep_add_fact"
+ADD_ADR_NAME = "mindkeep_add_adr"
+
+
+# ─────────────────────────── tool descriptors ────────────────────────────
+# Plain-Python data so this module stays SDK-free at import time. The
+# ``mcp.types.Tool`` instances are built on demand by ``build_write_tools``.
+
+
+_ADD_FACT_DESCRIPTION = (
+    "Persist a durable, project-relevant fact to this project's mindkeep "
+    "long-term memory. Use ONLY when the user explicitly asks to remember "
+    "something, or states a non-obvious project-specific fact (preferences, "
+    "naming conventions, decisions, gotchas) that future sessions will need. "
+    "Do NOT call for transient task notes, secrets, credentials, or generic "
+    "knowledge the model already has."
+)
+
+
+_ADD_FACT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "value": {"type": "string", "minLength": 1},
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "default": [],
+        },
+        "pin": {"type": "boolean", "default": False},
+    },
+    "required": ["value"],
+}
+
+
+_ADD_ADR_DESCRIPTION = (
+    "Record an architectural decision (title + decision + rationale) to "
+    "this project's mindkeep store. Use ONLY when the user has explicitly "
+    "framed something as a decision worth preserving across future "
+    "sessions. Do NOT use for transient notes, task lists, secrets, or "
+    "speculative options the user has not endorsed."
+)
+
+
+_ADD_ADR_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "title": {"type": "string", "minLength": 1},
+        "decision": {"type": "string", "minLength": 1},
+        "rationale": {"type": "string", "minLength": 1},
+        "status": {"type": "string", "default": "accepted"},
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "default": [],
+        },
+        "pin": {"type": "boolean", "default": False},
+    },
+    "required": ["title", "decision", "rationale"],
+}
+
+
+# ──────────────────────────── error helpers ──────────────────────────────
+
+
+def make_tool_error(
+    error_kind: str,
+    message: str,
+    fields: Dict[str, Any],
+) -> "CallToolResult":
+    """Build a recoverable tool-result error per DESIGN-v0.4.0 §10.1.
+
+    The MCP type system has no ``json`` content block, so the structured
+    payload is duplicated: ``content[0]`` is a ``TextContent`` carrying
+    the JSON-serialised payload (visible to the model in unstructured
+    form), and ``structuredContent`` carries the same payload as a dict
+    (consumed programmatically by hosts that surface structured output).
+    """
+
+    import json as _json
+
+    from mcp.types import CallToolResult, TextContent  # type: ignore[import-not-found]
+
+    payload: Dict[str, Any] = {
+        "error_kind": error_kind,
+        "message": message,
+        "fields": fields,
+    }
+    return CallToolResult(
+        content=[TextContent(type="text", text=_json.dumps(payload))],
+        structuredContent=payload,
+        isError=True,
+    )
+
+
+def make_internal_error(exc: BaseException) -> "Exception":
+    """Log ``exc`` traceback to stderr and return a fresh ``McpError``.
+
+    Per DESIGN-v0.4.0 §10.2, unhandled exceptions become JSON-RPC -32603
+    errors. The tracebacks must NOT leak into the tool result (they may
+    contain file paths, env, or unexpected data) — they go to stderr
+    only. The JSON-RPC payload contains just the exception class name.
+    """
+
+    from mcp.shared.exceptions import McpError  # type: ignore[import-not-found]
+    from mcp.types import INTERNAL_ERROR, ErrorData  # type: ignore[import-not-found]
+
+    traceback.print_exception(type(exc), exc, exc.__traceback__, file=sys.stderr)
+    return McpError(
+        ErrorData(
+            code=INTERNAL_ERROR,
+            message=f"mindkeep internal error: {type(exc).__name__}",
+        )
+    )
+
+
+# ──────────────────────────── handler helpers ────────────────────────────
+
+
+def _canonical_tags(tags: List[str] | None) -> List[str]:
+    """Mirror :func:`mindkeep.memory_api._tags_to_str` canonicalisation.
+
+    Stripped, empty-dropped, original order preserved. Used both for the
+    dedup boundary (compare against the same canonical form the API will
+    persist) and for the tool result echo.
+    """
+
+    if not tags:
+        return []
+    return [t.strip() for t in tags if t and t.strip()]
+
+
+def _find_duplicate_fact(
+    store: MemoryStore,
+    value: str,
+    tags: List[str],
+) -> int | None:
+    """Boundary dedup (§9.3) — exact ``value`` + canonical ``tags`` match.
+
+    Returns the existing fact id, or ``None`` if no exact duplicate
+    exists in the *current* project. Comparison is on the value
+    *as-passed* against the row's stored value column. If redaction
+    filters mutate content, two semantically-equal-but-pre-redaction-
+    different inputs will not collide here — the post-redaction store
+    still naturally appends and the user can ``mindkeep dedupe`` after.
+    Best-effort by design.
+    """
+
+    canonical = _canonical_tags(tags)
+    canonical_str = _tags_to_str(canonical)
+    # MemoryStore.list_facts has a ``limit`` param; pull a generous
+    # bound so we scan all rows in practice. The store is per-project
+    # and small (token cap × row count is bounded).
+    rows = store.list_facts(limit=10**9)
+    for row in rows:
+        if row.get("value") == value and (row.get("tags") or "") == canonical_str:
+            try:
+                return int(row["id"])
+            except (KeyError, TypeError, ValueError):  # pragma: no cover - defensive
+                continue
+    return None
+
+
+def _value_preview(value: str, max_len: int = 80) -> str:
+    """Short echo of the offending value for the dedup error payload."""
+
+    if len(value) <= max_len:
+        return value
+    return value[: max_len - 1] + "…"
+
+
+def _fact_row_view(store: MemoryStore, row_id: int) -> Dict[str, Any]:
+    """Return ``{id, token_estimate, pinned, tags}`` for a freshly-written fact.
+
+    ``MemoryStore.add_fact`` returns only an int rowid; the tool result
+    contract (§3.3 adapter responsibility) requires the richer view, so
+    the handler queries the row back. ``list_facts`` is the only public
+    read path; we filter in Python on the rowid.
+    """
+
+    rows = store.list_facts(limit=10**9)
+    for row in rows:
+        if int(row.get("id") or 0) == int(row_id):
+            return {
+                "id": int(row["id"]),
+                "token_estimate": int(row.get("token_estimate") or 0),
+                "pinned": bool(row.get("pin")),
+                "tags": [t for t in (row.get("tags") or "").split(",") if t],
+            }
+    # Theoretically unreachable — we just inserted this row in the
+    # same session. Falling back to a minimal payload keeps the handler
+    # honest if the schema ever drifts.
+    return {"id": int(row_id), "token_estimate": 0, "pinned": False, "tags": []}
+
+
+def _adr_row_view(store: MemoryStore, row_id: int) -> Dict[str, Any]:
+    """Return ``{id, token_estimate, pinned, status}`` for an inserted ADR."""
+
+    rows = store.list_adrs()
+    for row in rows:
+        if int(row.get("id") or 0) == int(row_id):
+            return {
+                "id": int(row["id"]),
+                "token_estimate": int(row.get("token_estimate") or 0),
+                "pinned": bool(row.get("pin")),
+                "status": str(row.get("status") or ""),
+            }
+    return {"id": int(row_id), "token_estimate": 0, "pinned": False, "status": ""}
+
+
+def _writeguard_error_payload(exc: WriteGuardError) -> "CallToolResult":
+    cap = getattr(exc, "cap", 0)
+    pre = getattr(exc, "pre_tokens", 0)
+    post = getattr(exc, "post_tokens", 0)
+    kind = getattr(exc, "kind", "unknown")
+    message = (
+        f"{kind} content exceeds the {cap}-token cap "
+        f"(post-redaction: {post}, pre-redaction: {pre})."
+    )
+    return make_tool_error(
+        "write_guard",
+        message,
+        {
+            "kind": kind,
+            "cap": cap,
+            "pre_tokens": pre,
+            "post_tokens": post,
+            "hint": (
+                "Shorten the value or split into multiple facts. The CLI "
+                "accepts --force; this MCP tool does not."
+            ),
+        },
+    )
+
+
+def _storage_error_payload(exc: StorageError) -> "CallToolResult":
+    return make_tool_error(
+        "storage",
+        f"storage error: {exc}",
+        {
+            "reason": str(exc),
+            "schema_version": getattr(exc, "schema_version", None),
+            "recoverable": bool(getattr(exc, "recoverable", False)),
+        },
+    )
+
+
+def _value_error_payload(exc: ValueError, *, field: str) -> "CallToolResult":
+    return make_tool_error(
+        "invalid_argument",
+        str(exc),
+        {"field": field, "value": None, "reason": str(exc)},
+    )
+
+
+# ──────────────────────────── tool handlers ──────────────────────────────
+
+
+async def _handle_add_fact(
+    store: MemoryStore, args: Dict[str, Any]
+) -> "CallToolResult":
+    value = args["value"]
+    tags = list(args.get("tags") or [])
+    pin = bool(args.get("pin", False))
+
+    # Pre-flight dedup at the boundary (§9.3). Done before WriteGuard
+    # because it short-circuits a future-WriteGuard-rejected duplicate
+    # too — though in practice WriteGuard is content-size-only so the
+    # ordering doesn't change correctness, just clarity.
+    existing = _find_duplicate_fact(store, value, tags)
+    if existing is not None:
+        return make_tool_error(
+            "duplicate",
+            f"a fact with this exact value and tags already exists (id={existing})",
+            {
+                "existing_id": existing,
+                "value_preview": _value_preview(value),
+                "tags": _canonical_tags(tags),
+            },
+        )
+
+    try:
+        row_id = store.add_fact(value, tags=tags, pin=pin)
+    except WriteGuardError as exc:
+        return _writeguard_error_payload(exc)
+    except ValueError as exc:
+        return _value_error_payload(exc, field="value")
+    except StorageError as exc:
+        return _storage_error_payload(exc)
+
+    payload = _fact_row_view(store, row_id)
+    from mcp.types import CallToolResult, TextContent  # type: ignore[import-not-found]
+    import json as _json
+
+    return CallToolResult(
+        content=[TextContent(type="text", text=_json.dumps(payload))],
+        structuredContent=payload,
+        isError=False,
+    )
+
+
+async def _handle_add_adr(
+    store: MemoryStore, args: Dict[str, Any]
+) -> "CallToolResult":
+    title = args["title"]
+    decision = args["decision"]
+    rationale = args["rationale"]
+    status = str(args.get("status") or "accepted")
+    tags = list(args.get("tags") or [])
+    pin = bool(args.get("pin", False))
+
+    # ADRs are NOT dedup'd at the boundary (DESIGN-v0.4.0 §9.3): their
+    # bodies are ~10× larger than facts and exact triple-string matches
+    # are vanishingly rare. WriteGuard still bounds the runaway case.
+
+    try:
+        row_id = store.add_adr(
+            title,
+            decision,
+            rationale,
+            status=status,
+            tags=tags,
+            pin=pin,
+        )
+    except WriteGuardError as exc:
+        return _writeguard_error_payload(exc)
+    except ValueError as exc:
+        return _value_error_payload(exc, field="title")
+    except StorageError as exc:
+        return _storage_error_payload(exc)
+
+    payload = _adr_row_view(store, row_id)
+    from mcp.types import CallToolResult, TextContent  # type: ignore[import-not-found]
+    import json as _json
+
+    return CallToolResult(
+        content=[TextContent(type="text", text=_json.dumps(payload))],
+        structuredContent=payload,
+        isError=False,
+    )
+
+
+# ──────────────────────────── registry builder ───────────────────────────
+
+
+def build_write_tools() -> Tuple[
+    List["Tool"],
+    Dict[str, Callable[[MemoryStore, Dict[str, Any]], Awaitable["CallToolResult"]]],
+]:
+    """Build write-tool descriptors and handler dispatch table.
+
+    Returns ``(tools, handlers)`` where ``tools`` is the list passed to
+    ``mcp.server.Server.list_tools()`` and ``handlers`` maps tool names
+    to async handlers. Imports the MCP SDK lazily (caller is in the
+    ``main()`` path that already required the extra).
+    """
+
+    from mcp.types import Tool  # type: ignore[import-not-found]
+
+    tools: List[Tool] = [
+        Tool(
+            name=ADD_FACT_NAME,
+            description=_ADD_FACT_DESCRIPTION,
+            inputSchema=_ADD_FACT_SCHEMA,
+        ),
+        Tool(
+            name=ADD_ADR_NAME,
+            description=_ADD_ADR_DESCRIPTION,
+            inputSchema=_ADD_ADR_SCHEMA,
+        ),
+    ]
+    handlers: Dict[
+        str, Callable[[MemoryStore, Dict[str, Any]], Awaitable["CallToolResult"]]
+    ] = {
+        ADD_FACT_NAME: _handle_add_fact,
+        ADD_ADR_NAME: _handle_add_adr,
+    }
+    return tools, handlers

--- a/tests/test_mcp_write_tools.py
+++ b/tests/test_mcp_write_tools.py
@@ -1,0 +1,454 @@
+"""Unit + round-trip tests for the v0.4 MCP write tools (#34).
+
+Covers DESIGN-v0.4.0 §3.3 (adapter responsibilities), §3.4 (stdio
+invariant), §3.5 (descriptions), §9 (write-permission story), and the
+§10 error-mapping table:
+
+* Registration gating on ``--allow-writes``.
+* ``mindkeep_add_fact`` happy path → ``{id, token_estimate, pinned, tags}``.
+* Boundary dedup → ``error_kind="duplicate"`` with ``existing_id``.
+* ``WriteGuardError`` → ``error_kind="write_guard"`` with structured fields.
+* ``ValueError`` → ``error_kind="invalid_argument"`` (via schema validation).
+* ``mindkeep_add_adr`` happy path.
+* Stdout-purity invariant (no bytes on stdout during a tool call).
+* Unhandled exception → JSON-RPC -32603 + traceback to stderr only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.shared.exceptions import McpError  # noqa: E402
+from mcp.types import (  # noqa: E402
+    METHOD_NOT_FOUND,
+    CallToolRequest,
+    CallToolRequestParams,
+)
+
+from mindkeep.mcp import tools_write  # noqa: E402
+from mindkeep.memory_api import MemoryStore  # noqa: E402
+from mindkeep.storage import StorageError, WriteGuardError  # noqa: E402
+
+
+# ──────────────────────────── helpers ────────────────────────────
+
+
+def _open_store(tmp_path: Path) -> MemoryStore:
+    """Open a fresh per-test MemoryStore rooted at ``tmp_path``."""
+
+    project = tmp_path / "proj"
+    project.mkdir(exist_ok=True)
+    (project / ".mindkeep").mkdir(exist_ok=True)
+    data = tmp_path / "data"
+    data.mkdir(exist_ok=True)
+    return MemoryStore.open(cwd=project, data_dir=data)
+
+
+def _build_server(tmp_path: Path, *, allow_writes: bool):
+    """Construct an in-process ``mcp.server.Server`` wired exactly like
+    ``mindkeep.mcp.server.main`` does — but without spawning a subprocess
+    or touching real stdio. Returns ``(srv, store, all_tools, dispatch)``
+    where ``dispatch(name, args)`` invokes the registered call_tool
+    handler and returns ``ServerResult`` (or raises ``McpError``).
+    """
+
+    import jsonschema
+
+    from mcp.server import Server
+    from mcp.types import ErrorData, ServerResult
+
+    from mindkeep.mcp.tools import TOOLS
+    from mindkeep.mcp.tools_write import build_write_tools, make_internal_error, make_tool_error
+
+    store = _open_store(tmp_path)
+    srv = Server("mindkeep-test")
+
+    all_tools = list(TOOLS)
+    all_handlers: dict = {}
+    if allow_writes:
+        wt, wh = build_write_tools()
+        all_tools.extend(wt)
+        all_handlers.update(wh)
+
+    @srv.list_tools()
+    async def _list_tools():
+        return list(all_tools)
+
+    async def _call(req):
+        name = req.params.name
+        args = req.params.arguments or {}
+        handler = all_handlers.get(name)
+        if handler is None:
+            raise McpError(ErrorData(code=METHOD_NOT_FOUND, message=f"Unknown tool: {name}"))
+        tool_def = next((t for t in all_tools if t.name == name), None)
+        if tool_def is not None:
+            try:
+                jsonschema.validate(instance=args, schema=tool_def.inputSchema)
+            except jsonschema.ValidationError as exc:
+                return ServerResult(
+                    make_tool_error(
+                        "invalid_argument",
+                        exc.message,
+                        {
+                            "field": ".".join(str(p) for p in exc.absolute_path),
+                            "value": exc.instance,
+                            "reason": exc.message,
+                        },
+                    )
+                )
+        try:
+            result = await handler(store, args)
+        except McpError:
+            raise
+        except Exception as exc:
+            raise make_internal_error(exc) from None
+        return ServerResult(result)
+
+    srv.request_handlers[CallToolRequest] = _call
+
+    def dispatch(name: str, arguments: dict):
+        req = CallToolRequest(
+            method="tools/call",
+            params=CallToolRequestParams(name=name, arguments=arguments),
+        )
+        return asyncio.run(_call(req))
+
+    return srv, store, all_tools, dispatch
+
+
+def _payload(server_result):
+    """Extract the structured payload from a ``ServerResult(CallToolResult)``."""
+
+    return server_result.root.structuredContent
+
+
+def _is_error(server_result) -> bool:
+    return bool(server_result.root.isError)
+
+
+# ───────────────────────── registration gating ─────────────────────────
+
+
+def test_write_tools_absent_without_allow_writes(tmp_path: Path) -> None:
+    """Read-only server (no ``--allow-writes``) → write tools not advertised."""
+
+    _, _store, all_tools, _ = _build_server(tmp_path, allow_writes=False)
+    names = {t.name for t in all_tools}
+    assert "mindkeep_add_fact" not in names
+    assert "mindkeep_add_adr" not in names
+
+
+def test_write_tools_present_with_allow_writes(tmp_path: Path) -> None:
+    _, _store, all_tools, _ = _build_server(tmp_path, allow_writes=True)
+    names = {t.name for t in all_tools}
+    assert {"mindkeep_add_fact", "mindkeep_add_adr"}.issubset(names)
+
+
+def test_write_tool_in_readonly_server_returns_method_not_found(
+    tmp_path: Path,
+) -> None:
+    """A client that calls a write tool against a read-only server must
+    not see it succeed; the SDK converts ``McpError`` to JSON-RPC -32601.
+    """
+
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=False)
+    with pytest.raises(McpError) as excinfo:
+        dispatch("mindkeep_add_fact", {"value": "hello"})
+    assert excinfo.value.error.code == METHOD_NOT_FOUND
+
+
+# ─────────────────────────── add_fact happy path ───────────────────────
+
+
+def test_add_fact_happy_path_returns_full_view(tmp_path: Path) -> None:
+    _, store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+
+    res = dispatch(
+        "mindkeep_add_fact",
+        {"value": "always use UTC for timestamps", "tags": ["conventions"]},
+    )
+    assert not _is_error(res)
+    payload = _payload(res)
+    assert isinstance(payload["id"], int) and payload["id"] >= 1
+    assert payload["pinned"] is False
+    assert payload["tags"] == ["conventions"]
+    assert payload["token_estimate"] > 0
+
+    rows = store.list_facts()
+    assert len(rows) == 1
+    assert rows[0]["value"] == "always use UTC for timestamps"
+
+
+def test_add_fact_pin_true_round_trips(tmp_path: Path) -> None:
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch(
+        "mindkeep_add_fact", {"value": "pinned fact", "tags": [], "pin": True}
+    )
+    assert not _is_error(res)
+    assert _payload(res)["pinned"] is True
+
+
+# ───────────────────────────── add_fact dedup ──────────────────────────
+
+
+def test_add_fact_dedup_returns_existing_id(tmp_path: Path) -> None:
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    first = dispatch(
+        "mindkeep_add_fact",
+        {"value": "use snake_case for python identifiers", "tags": ["style"]},
+    )
+    existing_id = _payload(first)["id"]
+
+    second = dispatch(
+        "mindkeep_add_fact",
+        {"value": "use snake_case for python identifiers", "tags": ["style"]},
+    )
+    assert _is_error(second)
+    p = _payload(second)
+    assert p["error_kind"] == "duplicate"
+    assert p["fields"]["existing_id"] == existing_id
+    assert p["fields"]["tags"] == ["style"]
+    assert "preview" in p["fields"]["value_preview"] or p["fields"]["value_preview"]
+
+
+def test_add_fact_different_tags_not_dedup(tmp_path: Path) -> None:
+    """Same ``value`` with different ``tags`` is allowed — design §9.3."""
+
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    a = dispatch("mindkeep_add_fact", {"value": "v", "tags": ["a"]})
+    b = dispatch("mindkeep_add_fact", {"value": "v", "tags": ["b"]})
+    assert not _is_error(a)
+    assert not _is_error(b)
+    assert _payload(a)["id"] != _payload(b)["id"]
+
+
+# ────────────────────────── add_fact WriteGuard ────────────────────────
+
+
+def test_add_fact_write_guard_exceeded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Content over cap → tool-result error w/ structured WriteGuard payload.
+
+    We tighten the per-fact cap via env var rather than synthesising a
+    multi-thousand-character string so the test stays fast and readable.
+    """
+
+    monkeypatch.setenv("MINDKEEP_FACTS_TOKEN_CAP", "5")
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+
+    res = dispatch(
+        "mindkeep_add_fact",
+        {"value": "this fact is intentionally far too long for the five-token cap"},
+    )
+    assert _is_error(res)
+    p = _payload(res)
+    assert p["error_kind"] == "write_guard"
+    assert p["fields"]["kind"] == "fact"
+    assert p["fields"]["cap"] == 5
+    assert p["fields"]["pre_tokens"] >= p["fields"]["post_tokens"]
+    assert "CLI" in p["fields"]["hint"] and "force" in p["fields"]["hint"]
+
+
+# ────────────────────── add_fact invalid_argument paths ────────────────
+
+
+def test_add_fact_missing_value_invalid_argument(tmp_path: Path) -> None:
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch("mindkeep_add_fact", {"tags": ["x"]})
+    assert _is_error(res)
+    assert _payload(res)["error_kind"] == "invalid_argument"
+
+
+def test_add_fact_empty_value_invalid_argument(tmp_path: Path) -> None:
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch("mindkeep_add_fact", {"value": ""})
+    assert _is_error(res)
+    assert _payload(res)["error_kind"] == "invalid_argument"
+
+
+def test_add_fact_wrong_type_invalid_argument(tmp_path: Path) -> None:
+    """``tags`` must be ``array`` per schema; a string fails validation."""
+
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch("mindkeep_add_fact", {"value": "ok", "tags": "nope"})
+    assert _is_error(res)
+    assert _payload(res)["error_kind"] == "invalid_argument"
+
+
+# ─────────────────────────────── add_adr ──────────────────────────────
+
+
+def test_add_adr_happy_path(tmp_path: Path) -> None:
+    _, store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch(
+        "mindkeep_add_adr",
+        {
+            "title": "Adopt MCP for v0.4",
+            "decision": "Ship a stdio MCP server in v0.4.",
+            "rationale": "Native integration beats CLI prompts for agents.",
+            "status": "accepted",
+            "tags": ["arch"],
+        },
+    )
+    assert not _is_error(res)
+    p = _payload(res)
+    assert p["status"] == "accepted"
+    assert p["pinned"] is False
+    assert p["token_estimate"] > 0
+    assert isinstance(p["id"], int)
+
+    rows = store.list_adrs()
+    assert len(rows) == 1
+
+
+def test_add_adr_write_guard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MINDKEEP_ADRS_TOKEN_CAP", "5")
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch(
+        "mindkeep_add_adr",
+        {
+            "title": "long",
+            "decision": "this is also pretty long for the five-token adr cap",
+            "rationale": "and more rationale text to push us well over the limit",
+        },
+    )
+    assert _is_error(res)
+    p = _payload(res)
+    assert p["error_kind"] == "write_guard"
+    assert p["fields"]["kind"] == "adr"
+
+
+# ───────────────────────── error-helper unit tests ─────────────────────
+
+
+def test_make_tool_error_text_content_mirrors_structured() -> None:
+    """The ``content[0]`` JSON text must round-trip to the same dict as
+    ``structuredContent`` — hosts that don't surface structured output
+    still see the full payload through the unstructured channel."""
+
+    res = tools_write.make_tool_error(
+        "duplicate", "msg", {"existing_id": 1, "tags": ["a"], "value_preview": "v"}
+    )
+    assert res.isError is True
+    assert res.structuredContent["error_kind"] == "duplicate"
+    parsed = json.loads(res.content[0].text)
+    assert parsed == res.structuredContent
+
+
+def test_writeguard_payload_shape() -> None:
+    exc = WriteGuardError("over cap", kind="fact", cap=100, pre_tokens=200, post_tokens=180)
+    res = tools_write._writeguard_error_payload(exc)  # noqa: SLF001
+    p = res.structuredContent
+    assert p["error_kind"] == "write_guard"
+    assert p["fields"] == {
+        "kind": "fact",
+        "cap": 100,
+        "pre_tokens": 200,
+        "post_tokens": 180,
+        "hint": p["fields"]["hint"],
+    }
+
+
+def test_storage_error_payload_shape() -> None:
+    res = tools_write._storage_error_payload(StorageError("schema mismatch"))  # noqa: SLF001
+    p = res.structuredContent
+    assert p["error_kind"] == "storage"
+    assert "reason" in p["fields"]
+    assert p["fields"]["recoverable"] is False
+
+
+# ─────────────────────────── stdio purity ─────────────────────────────
+
+
+def test_no_stdout_writes_during_tool_calls(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """DESIGN-v0.4.0 §3.4: write tools must not emit a single byte on
+    stdout. We exercise every error branch + happy path and assert the
+    captured stdout is empty.
+
+    ``capsys`` captures bytes Python writes to ``sys.stdout`` at the
+    process level — anything emitted via ``print()``, low-level
+    ``sys.stdout.write``, or a child ``traceback.print_*`` defaulting to
+    stdout will be caught here.
+    """
+
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    capsys.readouterr()  # drain anything from setup
+
+    dispatch("mindkeep_add_fact", {"value": "alpha"})
+    dispatch("mindkeep_add_fact", {"value": "alpha"})  # dedup branch
+    dispatch("mindkeep_add_fact", {"value": ""})  # invalid_argument branch
+    dispatch(
+        "mindkeep_add_adr",
+        {"title": "t", "decision": "d", "rationale": "r"},
+    )
+
+    out, _err = capsys.readouterr()
+    assert out == "", f"unexpected stdout output: {out!r}"
+
+
+# ─────────────────────── unhandled-exception path ─────────────────────
+
+
+def test_unhandled_exception_becomes_jsonrpc_internal_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unexpected exception inside the handler must surface as an
+    ``McpError(-32603)`` (so the SDK returns a JSON-RPC error response)
+    and the traceback must go to stderr only — never into the tool
+    result content (leak risk per DESIGN §10.2)."""
+
+    _, store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+
+    class _Boom(RuntimeError):
+        pass
+
+    def _explode(*_a, **_kw):
+        raise _Boom("unexpected database explosion: secret-token-AAA111")
+
+    monkeypatch.setattr(store, "add_fact", _explode)
+    capsys.readouterr()
+
+    with pytest.raises(McpError) as excinfo:
+        dispatch("mindkeep_add_fact", {"value": "hi"})
+
+    from mcp.types import INTERNAL_ERROR
+
+    assert excinfo.value.error.code == INTERNAL_ERROR
+    assert "_Boom" in excinfo.value.error.message
+    # The user-facing message must NOT carry the leaky exception text.
+    assert "secret-token-AAA111" not in excinfo.value.error.message
+
+    captured = capsys.readouterr()
+    assert captured.out == "", "traceback leaked to stdout"
+    assert "_Boom" in captured.err, "traceback should land on stderr"
+    assert "secret-token-AAA111" in captured.err
+
+
+# ────────────────────────── descriptions sanity ────────────────────────
+
+
+def test_tool_descriptions_name_intent_not_phrases(tmp_path: Path) -> None:
+    """DESIGN §3.5: descriptions describe intent, including ``do not``
+    guidance. We check both tools have a non-trivial description and
+    that it includes the ``Do NOT`` / ``DO NOT`` clause that survived
+    the v0.3 → v0.4 carry-forward."""
+
+    _, _store, all_tools, _ = _build_server(tmp_path, allow_writes=True)
+    by_name = {t.name: t for t in all_tools}
+    for name in ("mindkeep_add_fact", "mindkeep_add_adr"):
+        desc = by_name[name].description or ""
+        assert len(desc) >= 80, name
+        assert "Do NOT" in desc or "DO NOT" in desc, name


### PR DESCRIPTION
# mcp: write tools (#34)

Closes #34.

## What ships

Two new MCP tools registered behind `--allow-writes`:

| Tool | Schema | API call |
| --- | --- | --- |
| `mindkeep_add_fact` | `{value, tags?, pin?}` | `MemoryStore.add_fact(content=value, tags, pin)` |
| `mindkeep_add_adr`  | `{title, decision, rationale, status?, tags?, pin?}` | `MemoryStore.add_adr(...)` |

Implementation lives in `src/mindkeep/mcp/tools_write.py` (SDK imports lazy
per DESIGN-v0.4.0 §7.1). `server.py` composes the registry and installs a
custom `CallToolRequest` handler so unhandled exceptions become real
JSON-RPC `-32603` errors instead of being silently demoted to tool-result
errors by the SDK's decorator.

## Acceptance criteria — verification

Spec source-of-truth: the issue-comment "Acceptance criteria update from
design revision (post-rubber-duck)" and DESIGN-v0.4.0 §3, §9, §10.

- [x] **Read-only by default** (§9.1). When `--allow-writes` is absent, the
  write tools are not registered and do not appear in `tools/list`. A
  client that calls `mindkeep_add_fact` against a read-only server gets
  JSON-RPC `METHOD_NOT_FOUND`. (`test_write_tools_absent_without_allow_writes`,
  `test_write_tool_in_readonly_server_returns_method_not_found`.)
- [x] **`--allow-writes` registers them.** (`test_write_tools_present_with_allow_writes`.)
- [x] **`force` is not exposed to the model** (§9.2). The schemas omit
  `force` entirely; the handlers always call the API with `force=False`.
- [x] **Field rename** (§3.3). Tool input `value` is renamed to `content`
  inside the handler before calling `MemoryStore.add_fact` /
  `MemoryStore.add_adr`.
- [x] **Return-shape backfill** (§3.3). After insert, the handler queries
  the row back via `list_facts` / `list_adrs` and returns
  `{id, token_estimate, pinned, tags}` (fact) or
  `{id, token_estimate, pinned, status}` (adr).
- [x] **Boundary dedup for `add_fact`** (§9.3). Identical `(value, canonical
  tags)` in the current project returns `error_kind="duplicate"` with
  `existing_id`. ADRs are not dedup'd at the boundary (per §9.3).
  (`test_add_fact_dedup_returns_existing_id`,
  `test_add_fact_different_tags_not_dedup`.)
- [x] **`WriteGuardError` mapping** (§10.3). Surfaces as tool-result error
  with `error_kind="write_guard"`, `fields={kind, cap, pre_tokens,
  post_tokens, hint}`. The hint mentions the CLI `--force` escape hatch
  and that this MCP tool will not bypass the cap.
  (`test_add_fact_write_guard_exceeded`, `test_add_adr_write_guard`.)
- [x] **`ValueError` → `invalid_argument`** (§10). Schema-failure inputs
  (missing `value`, empty `value`, wrong `tags` type) all produce
  `error_kind="invalid_argument"`.
- [x] **`StorageError` → `storage`** (§10). Unit-tested via the helper.
- [x] **Unhandled exception → JSON-RPC `-32603`** (§10.2). The dispatcher
  re-raises as `McpError(INTERNAL_ERROR)`; the user-facing message
  carries only the exception class name; the full traceback goes to
  `stderr`. Verified the leaky exception text never appears in either
  the protocol message or stdout.
  (`test_unhandled_exception_becomes_jsonrpc_internal_error`.)
- [x] **stdio purity** (§3.4). Captured stdout is empty across happy-path,
  dedup, invalid_argument, and ADR happy-path tool calls.
  (`test_no_stdout_writes_during_tool_calls`.)
- [x] **Tool descriptions follow §3.5.** Both descriptions are ≥80 chars
  and contain explicit `Do NOT` guidance for transient state / secrets /
  generic knowledge. (`test_tool_descriptions_name_intent_not_phrases`.)
- [x] **`mindkeep_set_preference` is NOT registered** (§3, §9). A
  module-level docstring in `tools_write.py` documents the rationale
  and points at v0.5.
- [x] **Lazy-import contract preserved.** `import mindkeep` and
  `import mindkeep.cli` work without the `[mcp]` extra; importing
  `mindkeep.mcp.tools_write` does not pull the SDK at module load.

## Test count delta

`289 → 308` (+19) in core matrix. The new module is gated with
`pytest.importorskip("mcp")` so it skips when the `[mcp]` extra is not
installed and runs in the `mcp-extra` CI job.

## Line delta

```
 src/mindkeep/mcp/server.py       | +96 −15
 src/mindkeep/mcp/tools_write.py  | +396 (new)
 tests/test_mcp_write_tools.py    | +408 (new)
```

## Deviations from the original issue body

The original issue body predates the rubber-duck design revision; the
acceptance comment and DESIGN-v0.4.0 are authoritative. Deltas applied:

1. **No `mindkeep_set_preference`** (was: register). Deferred to v0.5 per
   §9 — preferences persist to a global cross-project DB and an
   autonomous agent could poison every project.
2. **No per-call `force`** (was: per-call). `force` is server-/CLI-only
   per §9.2; bypassing the cap requires human action.
3. **Read-only by default** (was: writes-on by default). Per §9.1.
4. **Server-side dedup for `add_fact`** (new in design §9.3) added.
5. **Error mapping uses §10's recoverable / protocol split.** Recoverable
   errors become tool-result `isError: true` with `structuredContent`
   carrying `{error_kind, message, fields}`. Only true protocol-level
   bugs become JSON-RPC errors. The original issue's `-32001 / -32002 /
   -32602` mapping is the v0.3-era proposal that §10 explicitly
   superseded.
6. **`error_kind` values** match design table (`write_guard`,
   `duplicate`, `invalid_argument`, `storage`) — not the
   `write_guard_exceeded` / `duplicate_fact` strings used in some
   pre-design notes. The design table in §10.1 wins.

## Coordination

`#35` (read tools) is in flight on `feat/v040-mcp-read`. We both touch
`src/mindkeep/mcp/server.py` (registration wiring) and may add to
`src/mindkeep/mcp/tools.py`. Whichever PR lands second will rebase. The
write-tool registry composes off `list(TOOLS)` so a read-tool PR that
populates `TOOLS` should merge cleanly with this one.

## Stop criteria

User runs the merge. CI must be green; do not merge from this PR.
