### PR TITLE
mcp: integrate adds claude-desktop / cursor-mcp / continue-mcp (#37)

### DIFF
--- a/src/mindkeep/_integrations.py
+++ b/src/mindkeep/_integrations.py
@@ -9,6 +9,14 @@ into any agent-instructions file.
 
 from __future__ import annotations
 
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
 CLAUDE = """\
 # Project memory (mindkeep)
 
@@ -233,6 +241,27 @@ TARGETS: dict[str, str] = {
     "generic": GENERIC,
 }
 
+# MCP-aware targets emit JSON snippets (or merge JSON config files) rather
+# than markdown agent-instruction blocks. They live in a separate dispatch
+# path in cli._cmd_integrate; the four targets above are unaffected.
+MCP_TARGETS: tuple[str, ...] = ("claude-desktop", "cursor-mcp", "continue-mcp")
+
+MCP_TARGET_DESCRIPTIONS: dict[str, str] = {
+    "claude": "Claude Code / claude.ai agent-instruction markdown block",
+    "copilot": "GitHub Copilot agent-instruction markdown block",
+    "cursor": "Cursor agent-instruction markdown block",
+    "generic": "vendor-neutral agent-instruction markdown block",
+    "claude-desktop": (
+        "Claude Desktop MCP config (claude_desktop_config.json, JSON merge)"
+    ),
+    "cursor-mcp": (
+        "Cursor MCP config (~/.cursor/mcp.json, JSON merge)"
+    ),
+    "continue-mcp": (
+        "Continue MCP config (~/.continue/config.json, snippet only)"
+    ),
+}
+
 
 def render(target: str) -> str:
     """Return the snippet for *target*. Raises KeyError if unknown."""
@@ -240,5 +269,236 @@ def render(target: str) -> str:
 
 
 def supported() -> list[str]:
-    """Return the list of supported target names in stable order."""
+    """Return the list of supported markdown target names (stable order)."""
     return ["claude", "copilot", "cursor", "generic"]
+
+
+def supported_all() -> list[str]:
+    """Return all supported target names (markdown + MCP), in stable order."""
+    return [*supported(), *MCP_TARGETS]
+
+
+# ────────────────────────── MCP target builders ──────────────────────────
+#
+# These are pure data-returning helpers: they never print, never write, and
+# never read the filesystem (the cwd is captured by the caller and passed
+# in). The CLI layer (`_cmd_integrate`) is responsible for I/O and for
+# routing to merge_json / write atomically. See DESIGN-v0.4.0.md §12.
+
+
+_WRITES_HINT = (
+    "to enable write tools, add \"--allow-writes\" to args (read-only by "
+    "default — see DESIGN-v0.4.0.md §9.1)"
+)
+
+
+def mcp_snippet(target: str, project_dir: str) -> dict[str, Any]:
+    """Return the JSON-serialisable snippet for an MCP *target*.
+
+    The snippet always bakes the *project_dir* (the cwd at integrate-time
+    or an explicit ``--project-dir``) into the generated config — see
+    DESIGN-v0.4.0.md §8.6 / §12.1. It never includes ``--allow-writes``;
+    users opt into writes by hand-editing.
+
+    For ``claude-desktop`` and ``cursor-mcp`` the returned dict is the
+    full config skeleton (with ``mcpServers.mindkeep`` populated). For
+    ``continue-mcp`` it's the Continue-shaped config skeleton (with the
+    ``modelContextProtocolServers`` list containing one entry).
+    """
+    if target in ("claude-desktop", "cursor-mcp"):
+        return {
+            "mcpServers": {
+                "mindkeep": {
+                    "command": "mindkeep-mcp",
+                    "args": [],
+                    "env": {"MINDKEEP_PROJECT_DIR": project_dir},
+                }
+            }
+        }
+    if target == "continue-mcp":
+        return {
+            "experimental": {
+                "modelContextProtocolServers": [
+                    {
+                        "transport": {
+                            "type": "stdio",
+                            "command": "mindkeep-mcp",
+                            "args": ["--project-dir", project_dir],
+                        }
+                    }
+                ]
+            }
+        }
+    raise KeyError(target)
+
+
+def mcp_snippet_text(target: str, project_dir: str) -> str:
+    """Return the human-pasteable JSON text for an MCP *target* snippet."""
+    return json.dumps(mcp_snippet(target, project_dir), indent=2) + "\n"
+
+
+def default_config_path(target: str) -> Path:
+    """Return the OS-appropriate default host config path for *target*.
+
+    Used when the user passes ``--in-place`` (no explicit ``--out PATH``).
+    """
+    home = Path.home()
+    if target == "claude-desktop":
+        if sys.platform == "win32":
+            base = os.environ.get("APPDATA")
+            root = Path(base) if base else home / "AppData" / "Roaming"
+            return root / "Claude" / "claude_desktop_config.json"
+        if sys.platform == "darwin":
+            return (
+                home / "Library" / "Application Support"
+                / "Claude" / "claude_desktop_config.json"
+            )
+        return home / ".config" / "Claude" / "claude_desktop_config.json"
+    if target == "cursor-mcp":
+        return home / ".cursor" / "mcp.json"
+    if target == "continue-mcp":
+        return home / ".continue" / "config.json"
+    raise KeyError(target)
+
+
+# ─────────────────────────── JSON merge helpers ──────────────────────────
+
+
+_JSONC_LINE_COMMENT = re.compile(r'(?<!:)//')
+_JSONC_BLOCK_COMMENT = re.compile(r'/\*')
+
+
+class JsoncDetectedError(ValueError):
+    """Raised when a config file appears to contain JSONC comments."""
+
+
+class MindkeepEntryExistsError(RuntimeError):
+    """Raised when ``mcpServers.mindkeep`` is already present and no --force."""
+
+
+def _looks_like_jsonc(raw: str) -> bool:
+    """Return True if *raw* contains line or block comments outside strings.
+
+    Cheap heuristic — strips string literals first, then looks for ``//``
+    or ``/*``. Good enough to refuse JSONC merges with a helpful error
+    rather than silently corrupting the user's config.
+    """
+    # Strip double-quoted strings (handles escapes) and single-line
+    # JSON-strings; this is conservative enough to not false-positive on
+    # URLs like "https://" living inside a value.
+    no_strings = re.sub(r'"(?:\\.|[^"\\])*"', '""', raw)
+    return bool(
+        _JSONC_LINE_COMMENT.search(no_strings)
+        or _JSONC_BLOCK_COMMENT.search(no_strings)
+    )
+
+
+def load_json_config(path: Path) -> dict[str, Any]:
+    """Load *path* as strict JSON, returning ``{}`` for missing/empty files.
+
+    Refuses JSONC (raises :class:`JsoncDetectedError`).
+    """
+    if not path.exists():
+        return {}
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        return {}
+    if _looks_like_jsonc(raw):
+        raise JsoncDetectedError(
+            f"{path} appears to contain JSONC comments (// or /*); "
+            f"mindkeep refuses in-place merge for JSONC. Re-run without "
+            f"--out to print the snippet to stdout, then paste it manually."
+        )
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"{path} is not valid JSON: {e.msg} (line {e.lineno}, col "
+            f"{e.colno}). Refusing to overwrite a file we can't parse; "
+            f"re-run without --out to print the snippet to stdout."
+        ) from e
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"{path} top-level value is not a JSON object (found "
+            f"{type(data).__name__}); refusing to merge."
+        )
+    return data
+
+
+def merge_mcp_config(
+    existing: dict[str, Any],
+    target: str,
+    project_dir: str,
+    *,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Merge the mindkeep MCP entry into *existing* config for *target*.
+
+    Preserves all unrelated top-level keys and unrelated ``mcpServers``
+    entries. If ``mcpServers.mindkeep`` already exists and ``force`` is
+    False, raises :class:`MindkeepEntryExistsError`. The returned dict is
+    a new object — the input is not mutated.
+    """
+    if target not in ("claude-desktop", "cursor-mcp"):
+        raise KeyError(
+            f"merge_mcp_config: unsupported target {target!r} "
+            f"(only claude-desktop and cursor-mcp support in-place merge)"
+        )
+
+    merged: dict[str, Any] = dict(existing)
+    servers_in = merged.get("mcpServers")
+    if servers_in is not None and not isinstance(servers_in, dict):
+        raise ValueError(
+            "existing 'mcpServers' is not a JSON object; refusing to merge."
+        )
+    servers: dict[str, Any] = dict(servers_in) if servers_in else {}
+
+    if "mindkeep" in servers and not force:
+        raise MindkeepEntryExistsError(
+            "a 'mindkeep' entry already exists in mcpServers; pass --force "
+            "to overwrite (other servers will be preserved)."
+        )
+
+    snippet = mcp_snippet(target, project_dir)
+    servers["mindkeep"] = snippet["mcpServers"]["mindkeep"]
+    merged["mcpServers"] = servers
+    return merged
+
+
+def atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    """Write *data* to *path* atomically: tmp file in same dir, then rename.
+
+    The caller is responsible for backing up the previous file (see
+    :func:`backup_file`) before invoking this — atomic_write_json itself
+    only guarantees torn-write safety on the destination.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(data, indent=2) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def backup_file(path: Path) -> Path | None:
+    """Copy *path* to ``<path>.bak`` (overwriting any prior backup).
+
+    Returns the backup path, or ``None`` if *path* didn't exist (nothing
+    to back up). Pure file copy — no JSON parsing, so a malformed file is
+    preserved verbatim.
+    """
+    if not path.exists():
+        return None
+    bak = path.with_name(path.name + ".bak")
+    bak.write_bytes(path.read_bytes())
+    return bak

--- a/src/mindkeep/cli.py
+++ b/src/mindkeep/cli.py
@@ -904,16 +904,20 @@ def _cmd_integrate(args: argparse.Namespace) -> int:
     from . import _integrations
 
     if getattr(args, "list", False):
-        for name in _integrations.supported():
+        for name in _integrations.supported_all():
             print(name)
         return 0
 
     target = args.target
-    if target is None or target not in _integrations.TARGETS:
-        supported = ", ".join(_integrations.supported())
+    all_targets = _integrations.supported_all()
+    if target is None or target not in all_targets:
+        supported = ", ".join(all_targets)
         print(f"error: unknown target: {target!r}", file=sys.stderr)
         print(f"supported targets: {supported}", file=sys.stderr)
         return 2
+
+    if target in _integrations.MCP_TARGETS:
+        return _cmd_integrate_mcp(args, target)
 
     snippet = _integrations.render(target)
 
@@ -931,6 +935,120 @@ def _cmd_integrate(args: argparse.Namespace) -> int:
         return 0
 
     sys.stdout.write(snippet)
+    return 0
+
+
+def _cmd_integrate_mcp(args: argparse.Namespace, target: str) -> int:
+    """Handle the JSON / JSONC MCP integrate targets.
+
+    See DESIGN-v0.4.0.md §12 for the full behavior contract:
+
+    - Default (no ``--out``): print snippet to stdout. No file writes.
+    - ``continue-mcp``: ALWAYS prints to stdout (JSONC merge deferred —
+      a stderr note is emitted if the user passed ``--out``).
+    - ``claude-desktop`` / ``cursor-mcp`` with ``--out PATH``: parse the
+      file as strict JSON (refusing JSONC), merge ``mcpServers.mindkeep``
+      preserving every other key, copy the original to ``<path>.bak``,
+      then write atomically. ``--force`` is required to overwrite an
+      existing ``mindkeep`` entry; ``--dry-run`` skips the write.
+    """
+    from . import _integrations
+
+    project_dir = getattr(args, "project_dir", None) or os.getcwd()
+    project_dir = str(Path(project_dir).resolve())
+
+    # Soft warning if the user is integrating from a directory with no
+    # `.mindkeep/` marker. We still bake the cwd (DESIGN-v0.4.0 §8.6 is
+    # explicit that integrate-time cwd wins) but flag it so the user can
+    # rerun from the right project root if this was accidental.
+    if not (Path(project_dir) / ".mindkeep").is_dir():
+        print(
+            f"warning: {project_dir} has no .mindkeep/ directory; baking it "
+            f"anyway. Re-run from your project root or pass --project-dir "
+            f"if this is wrong.",
+            file=sys.stderr,
+        )
+
+    snippet_text = _integrations.mcp_snippet_text(target, project_dir)
+    out = getattr(args, "out", None)
+    dry_run = bool(getattr(args, "dry_run", False))
+    force = bool(getattr(args, "force", False))
+
+    # continue-mcp is snippet-to-stdout only in v0.4 (JSONC round-trip
+    # deferred). Honour --out by warning and falling through to stdout.
+    if target == "continue-mcp":
+        if out:
+            print(
+                "note: continue-mcp does not support in-place merge in v0.4 "
+                "(Continue config is JSONC); printing snippet to stdout for "
+                "manual paste. See docs/MCP-INSTALL.md.",
+                file=sys.stderr,
+            )
+        sys.stdout.write(snippet_text)
+        print(
+            "# to enable write tools, add \"--allow-writes\" to args "
+            "(read-only by default).",
+            file=sys.stderr,
+        )
+        return 0
+
+    if not out:
+        if force:
+            print(
+                "warning: --force has no effect without --out (snippet-only "
+                "mode does not write).",
+                file=sys.stderr,
+            )
+        sys.stdout.write(snippet_text)
+        print(
+            "# to enable write tools, add \"--allow-writes\" to args "
+            "(read-only by default).",
+            file=sys.stderr,
+        )
+        return 0
+
+    out_path = Path(out)
+    try:
+        existing = _integrations.load_json_config(out_path)
+    except _integrations.JsoncDetectedError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        merged = _integrations.merge_mcp_config(
+            existing, target, project_dir, force=force
+        )
+    except _integrations.MindkeepEntryExistsError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    merged_text = json.dumps(merged, indent=2) + "\n"
+
+    if dry_run:
+        sys.stdout.write(merged_text)
+        print(
+            f"# dry-run: {out_path} would be written ({len(merged_text)} "
+            f"bytes); no changes made.",
+            file=sys.stderr,
+        )
+        return 0
+
+    bak = _integrations.backup_file(out_path)
+    _integrations.atomic_write_json(out_path, merged)
+    if bak is not None:
+        print(f"backed up previous config to {bak}", file=sys.stderr)
+    print(f"wrote {out_path}", file=sys.stderr)
+    print(
+        "# to enable write tools, add \"--allow-writes\" to args in the "
+        "mindkeep entry (read-only by default).",
+        file=sys.stderr,
+    )
     return 0
 
 
@@ -1188,11 +1306,27 @@ def _build_parser() -> argparse.ArgumentParser:
     pint = sub.add_parser(
         "integrate",
         help="emit an integration snippet for an AI coding agent "
-             "(claude|copilot|cursor|generic)",
+             "(markdown: claude|copilot|cursor|generic; "
+             "MCP: claude-desktop|cursor-mcp|continue-mcp)",
+        description=(
+            "Emit an integration snippet for an AI coding agent.\n\n"
+            "Markdown targets (paste into agent-instruction files):\n"
+            "  claude         Claude Code / claude.ai instruction block\n"
+            "  copilot        GitHub Copilot instruction block\n"
+            "  cursor         Cursor instruction block\n"
+            "  generic        vendor-neutral instruction block\n\n"
+            "MCP targets (register the mindkeep MCP server):\n"
+            "  claude-desktop Claude Desktop config (JSON merge with --out)\n"
+            "  cursor-mcp     Cursor MCP config (JSON merge with --out)\n"
+            "  continue-mcp   Continue config (snippet-to-stdout only; "
+            "JSONC merge deferred)\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     pint.add_argument(
         "target", nargs="?", default=None, metavar="<target>",
-        help="one of: claude, copilot, cursor, generic",
+        help="one of: claude, copilot, cursor, generic, "
+             "claude-desktop, cursor-mcp, continue-mcp",
     )
     pint.add_argument(
         "--list", action="store_true",
@@ -1200,12 +1334,28 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     pint.add_argument(
         "--out", default=None, metavar="PATH",
-        help="write the snippet to PATH instead of stdout "
-             "(creates parent dirs; refuses to overwrite without --force)",
+        help="markdown targets: write snippet to PATH (refuses to overwrite "
+             "without --force). MCP targets: merge into the JSON config at "
+             "PATH (preserving unrelated keys; refuses if a 'mindkeep' "
+             "entry exists without --force). continue-mcp ignores --out "
+             "(JSONC merge deferred to a future release).",
     )
     pint.add_argument(
         "--force", action="store_true",
-        help="overwrite --out PATH if it already exists",
+        help="markdown: overwrite --out PATH if it exists. MCP: overwrite "
+             "an existing 'mindkeep' entry inside mcpServers.",
+    )
+    pint.add_argument(
+        "--dry-run", action="store_true",
+        help="MCP targets only: with --out, print the would-be merged "
+             "config to stdout without writing.",
+    )
+    pint.add_argument(
+        "--project-dir", default=None, metavar="PATH",
+        help="MCP targets only: bake PATH into the snippet's "
+             "MINDKEEP_PROJECT_DIR (claude-desktop / cursor-mcp) or "
+             "--project-dir argv (continue-mcp). Defaults to the current "
+             "working directory.",
     )
 
     # ``mcp`` subcommand. Parser construction MUST stay free of any

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -1,8 +1,10 @@
-"""Tests for `mindkeep integrate <target>` (P1-5, #10)."""
+"""Tests for `mindkeep integrate <target>` (P1-5, #10; #37 MCP targets)."""
 
 from __future__ import annotations
 
 import io
+import json
+import os
 import re
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -14,6 +16,8 @@ from mindkeep.cli import main as cli_main
 
 
 TARGETS = ["claude", "copilot", "cursor", "generic"]
+MCP_TARGETS = ["claude-desktop", "cursor-mcp", "continue-mcp"]
+ALL_TARGETS = TARGETS + MCP_TARGETS
 TARGET_KEYWORDS = {
     "claude": "Claude",
     "copilot": "Copilot",
@@ -29,11 +33,11 @@ def _run(*argv: str) -> tuple[int, str, str]:
     return rc, out.getvalue(), err.getvalue()
 
 
-def test_list_lists_four_targets() -> None:
+def test_list_lists_all_targets() -> None:
     rc, out, _ = _run("integrate", "--list")
     assert rc == 0
     listed = [ln.strip() for ln in out.strip().splitlines() if ln.strip()]
-    assert listed == TARGETS
+    assert listed == ALL_TARGETS
 
 
 @pytest.mark.parametrize("target", TARGETS)
@@ -65,7 +69,9 @@ def test_snippet_valid_utf8(target: str) -> None:
 def test_unknown_target_exits_2() -> None:
     rc, _, err = _run("integrate", "nonsuch")
     assert rc == 2
-    assert "supported targets: claude, copilot, cursor, generic" in err
+    # Error message lists every supported target (markdown + MCP).
+    for name in ALL_TARGETS:
+        assert name in err
 
 
 def test_no_target_and_no_list_exits_2() -> None:
@@ -104,3 +110,342 @@ def test_out_force_overwrites(tmp_path: Path) -> None:
     assert rc == 0
     assert "OLD" not in dest.read_text(encoding="utf-8")
     assert "mindkeep recall" in dest.read_text(encoding="utf-8")
+
+
+# ───────────────────────── MCP target tests (#37) ─────────────────────────
+
+
+@pytest.fixture
+def project_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A tmp dir that looks like a mindkeep project (has .mindkeep/), set as cwd.
+
+    Avoids the soft "no .mindkeep/ directory" stderr warning so tests can
+    assert on otherwise-empty stderr without false positives.
+    """
+    (tmp_path / ".mindkeep").mkdir()
+    monkeypatch.chdir(tmp_path)
+    return tmp_path.resolve()
+
+
+def test_claude_desktop_stdout_default(project_cwd: Path) -> None:
+    rc, out, err = _run("integrate", "claude-desktop")
+    assert rc == 0
+    payload = json.loads(out)
+    server = payload["mcpServers"]["mindkeep"]
+    assert server["command"] == "mindkeep-mcp"
+    assert server["args"] == []
+    assert server["env"]["MINDKEEP_PROJECT_DIR"] == str(project_cwd)
+    # Read-only by default — no --allow-writes anywhere in the snippet.
+    assert "--allow-writes" not in out
+    # The post-print stderr hint mentions the opt-in path.
+    assert "--allow-writes" in err
+
+
+def test_cursor_mcp_stdout_default(project_cwd: Path) -> None:
+    rc, out, _ = _run("integrate", "cursor-mcp")
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["mcpServers"]["mindkeep"]["command"] == "mindkeep-mcp"
+    assert (
+        payload["mcpServers"]["mindkeep"]["env"]["MINDKEEP_PROJECT_DIR"]
+        == str(project_cwd)
+    )
+
+
+def test_continue_mcp_stdout_default(project_cwd: Path) -> None:
+    rc, out, _ = _run("integrate", "continue-mcp")
+    assert rc == 0
+    payload = json.loads(out)
+    server = payload["experimental"]["modelContextProtocolServers"][0]
+    assert server["transport"]["command"] == "mindkeep-mcp"
+    assert server["transport"]["args"] == ["--project-dir", str(project_cwd)]
+    assert "--allow-writes" not in out
+
+
+def test_continue_mcp_ignores_out(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    dest = tmp_path / "config.json"
+    dest.write_text("{}", encoding="utf-8")
+    rc, out, err = _run("integrate", "continue-mcp", "--out", str(dest))
+    assert rc == 0
+    # Snippet still printed to stdout.
+    assert json.loads(out)["experimental"]
+    # File untouched.
+    assert dest.read_text(encoding="utf-8") == "{}"
+    assert "does not support in-place merge" in err
+
+
+def test_project_dir_flag_overrides_cwd(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    rc, out, _ = _run(
+        "integrate", "claude-desktop", "--project-dir", str(other)
+    )
+    assert rc == 0
+    payload = json.loads(out)
+    assert (
+        payload["mcpServers"]["mindkeep"]["env"]["MINDKEEP_PROJECT_DIR"]
+        == str(other.resolve())
+    )
+
+
+def test_non_project_cwd_warns_but_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc, out, err = _run("integrate", "claude-desktop")
+    assert rc == 0
+    payload = json.loads(out)
+    assert (
+        payload["mcpServers"]["mindkeep"]["env"]["MINDKEEP_PROJECT_DIR"]
+        == str(tmp_path.resolve())
+    )
+    assert "no .mindkeep/" in err
+
+
+def test_mcp_out_writes_empty_file(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    dest = tmp_path / "claude_desktop_config.json"
+    rc, out, err = _run("integrate", "claude-desktop", "--out", str(dest))
+    assert rc == 0
+    assert out == ""
+    payload = json.loads(dest.read_text(encoding="utf-8"))
+    assert list(payload.keys()) == ["mcpServers"]
+    assert payload["mcpServers"]["mindkeep"]["command"] == "mindkeep-mcp"
+    # No backup expected — the file didn't exist before.
+    assert not (tmp_path / "claude_desktop_config.json.bak").exists()
+    assert "wrote" in err
+
+
+def test_mcp_out_preserves_unrelated_keys(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    dest = tmp_path / "claude_desktop_config.json"
+    existing = {
+        "someOtherSetting": 1,
+        "theme": "dark",
+        "mcpServers": {
+            "other-server": {
+                "command": "other-mcp",
+                "args": ["--flag"],
+            }
+        },
+    }
+    dest.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    rc, _, _ = _run("integrate", "claude-desktop", "--out", str(dest))
+    assert rc == 0
+
+    merged = json.loads(dest.read_text(encoding="utf-8"))
+    assert merged["someOtherSetting"] == 1
+    assert merged["theme"] == "dark"
+    assert merged["mcpServers"]["other-server"]["command"] == "other-mcp"
+    assert (
+        merged["mcpServers"]["mindkeep"]["env"]["MINDKEEP_PROJECT_DIR"]
+        == str(project_cwd)
+    )
+
+    # Backup should contain the original content.
+    bak = dest.with_name(dest.name + ".bak")
+    assert bak.exists()
+    assert json.loads(bak.read_text(encoding="utf-8")) == existing
+
+
+def test_mcp_out_refuses_existing_mindkeep_entry(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    dest = tmp_path / "config.json"
+    existing = {
+        "mcpServers": {
+            "mindkeep": {"command": "old-mindkeep", "args": []},
+            "other": {"command": "other"},
+        }
+    }
+    dest.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    original_text = dest.read_text(encoding="utf-8")
+
+    rc, _, err = _run("integrate", "claude-desktop", "--out", str(dest))
+    assert rc == 2
+    assert "already exists" in err
+    # File untouched.
+    assert dest.read_text(encoding="utf-8") == original_text
+    # No backup written on the refusal path.
+    assert not dest.with_name(dest.name + ".bak").exists()
+
+
+def test_mcp_out_force_overwrites_mindkeep_entry(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    dest = tmp_path / "config.json"
+    existing = {
+        "mcpServers": {
+            "mindkeep": {"command": "old-mindkeep", "args": ["--legacy"]},
+            "other": {"command": "other"},
+        }
+    }
+    dest.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    rc, _, _ = _run(
+        "integrate", "claude-desktop", "--out", str(dest), "--force"
+    )
+    assert rc == 0
+
+    merged = json.loads(dest.read_text(encoding="utf-8"))
+    # Mindkeep entry was overwritten (no more "--legacy").
+    assert merged["mcpServers"]["mindkeep"]["command"] == "mindkeep-mcp"
+    assert merged["mcpServers"]["mindkeep"]["args"] == []
+    # Other server preserved.
+    assert merged["mcpServers"]["other"]["command"] == "other"
+    # Backup contains the previous mindkeep entry.
+    bak = dest.with_name(dest.name + ".bak")
+    assert bak.exists()
+    bak_data = json.loads(bak.read_text(encoding="utf-8"))
+    assert bak_data["mcpServers"]["mindkeep"]["command"] == "old-mindkeep"
+
+
+def test_mcp_out_dry_run_does_not_write(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    dest = tmp_path / "config.json"
+    existing = {"mcpServers": {"other": {"command": "other"}}}
+    dest.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    original = dest.read_text(encoding="utf-8")
+
+    rc, out, err = _run(
+        "integrate", "claude-desktop", "--out", str(dest), "--dry-run"
+    )
+    assert rc == 0
+    # Disk unchanged.
+    assert dest.read_text(encoding="utf-8") == original
+    assert not dest.with_name(dest.name + ".bak").exists()
+    # Stdout shows the would-be merged content.
+    payload = json.loads(out)
+    assert payload["mcpServers"]["mindkeep"]["command"] == "mindkeep-mcp"
+    assert payload["mcpServers"]["other"]["command"] == "other"
+    assert "dry-run" in err
+
+
+def test_mcp_out_jsonc_refused(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    dest = tmp_path / "config.json"
+    dest.write_text(
+        '{\n  "x": 1, // a JSONC comment\n  "mcpServers": {}\n}\n',
+        encoding="utf-8",
+    )
+    original = dest.read_text(encoding="utf-8")
+
+    rc, _, err = _run("integrate", "claude-desktop", "--out", str(dest))
+    assert rc == 2
+    assert "JSONC" in err
+    # File untouched.
+    assert dest.read_text(encoding="utf-8") == original
+
+
+def test_mcp_out_block_comment_refused(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    dest = tmp_path / "config.json"
+    dest.write_text(
+        '/* header */\n{\n  "mcpServers": {}\n}\n', encoding="utf-8"
+    )
+    rc, _, err = _run("integrate", "claude-desktop", "--out", str(dest))
+    assert rc == 2
+    assert "JSONC" in err
+
+
+def test_mcp_out_invalid_json_refused(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    dest = tmp_path / "config.json"
+    dest.write_text("{ this is not json", encoding="utf-8")
+    rc, _, err = _run("integrate", "claude-desktop", "--out", str(dest))
+    assert rc == 2
+    assert "not valid JSON" in err
+
+
+def test_cursor_mcp_out_happy_path(
+    project_cwd: Path, tmp_path: Path
+) -> None:
+    dest = tmp_path / "mcp.json"
+    rc, _, _ = _run("integrate", "cursor-mcp", "--out", str(dest))
+    assert rc == 0
+    payload = json.loads(dest.read_text(encoding="utf-8"))
+    assert payload["mcpServers"]["mindkeep"]["command"] == "mindkeep-mcp"
+
+
+def test_cursor_mcp_out_force(project_cwd: Path, tmp_path: Path) -> None:
+    dest = tmp_path / "mcp.json"
+    dest.write_text(
+        json.dumps({"mcpServers": {"mindkeep": {"command": "old"}}}),
+        encoding="utf-8",
+    )
+    # No --force → refuse.
+    rc, _, _ = _run("integrate", "cursor-mcp", "--out", str(dest))
+    assert rc == 2
+    # With --force → overwrite.
+    rc, _, _ = _run("integrate", "cursor-mcp", "--out", str(dest), "--force")
+    assert rc == 0
+    payload = json.loads(dest.read_text(encoding="utf-8"))
+    assert payload["mcpServers"]["mindkeep"]["command"] == "mindkeep-mcp"
+
+
+def test_force_without_out_warns(project_cwd: Path) -> None:
+    rc, _, err = _run("integrate", "claude-desktop", "--force")
+    assert rc == 0
+    assert "--force has no effect" in err
+
+
+def test_existing_markdown_targets_unchanged_regression() -> None:
+    """Adding MCP targets must not regress markdown snippets."""
+    for t in TARGETS:
+        rc, out, _ = _run("integrate", t)
+        assert rc == 0
+        assert "mindkeep recall" in out
+        assert "mindkeep show" in out
+        # No JSON contamination.
+        assert '"mcpServers"' not in out
+
+
+# ──────────────────────── unit tests for helpers ────────────────────────
+
+
+def test_mcp_snippet_shape_claude_desktop() -> None:
+    snippet = _integrations.mcp_snippet("claude-desktop", "/p")
+    assert snippet == {
+        "mcpServers": {
+            "mindkeep": {
+                "command": "mindkeep-mcp",
+                "args": [],
+                "env": {"MINDKEEP_PROJECT_DIR": "/p"},
+            }
+        }
+    }
+
+
+def test_mcp_snippet_shape_continue() -> None:
+    snippet = _integrations.mcp_snippet("continue-mcp", "/p")
+    server = snippet["experimental"]["modelContextProtocolServers"][0]
+    assert server["transport"]["command"] == "mindkeep-mcp"
+    assert server["transport"]["args"] == ["--project-dir", "/p"]
+
+
+def test_jsonc_detector_ignores_strings_with_double_slash() -> None:
+    raw = '{"url": "https://example.com"}'
+    assert not _integrations._looks_like_jsonc(raw)
+
+
+def test_jsonc_detector_catches_line_comment() -> None:
+    raw = '{ // hi\n}'
+    assert _integrations._looks_like_jsonc(raw)
+
+
+def test_default_config_path_known_targets() -> None:
+    for t in MCP_TARGETS:
+        p = _integrations.default_config_path(t)
+        assert isinstance(p, Path)
+        assert p.is_absolute()


### PR DESCRIPTION
Implements #37: extends `mindkeep integrate` with three new MCP-aware targets per DESIGN-v0.4.0.md §12.

## Targets added

| Target | Format | Default | With `--out` |
|---|---|---|---|
| `claude-desktop` | strict JSON | print snippet to stdout | merge `mcpServers.mindkeep` into config at PATH |
| `cursor-mcp` | strict JSON | print snippet to stdout | merge `mcpServers.mindkeep` into config at PATH |
| `continue-mcp` | JSONC | print snippet to stdout | **ignored** (stderr note) — JSONC merge deferred |

The four existing markdown targets (`claude`/`copilot`/`cursor`/`generic`) are unchanged.

## Acceptance criteria verification

- ✅ Snippets bake `MINDKEEP_PROJECT_DIR` (claude-desktop / cursor-mcp) or `--project-dir` argv (continue-mcp) from integrate-time cwd, overridable with `--project-dir` flag.
- ✅ No `--allow-writes` in any generated config; read-only by default with a stderr opt-in hint.
- ✅ `--out PATH` merges into strict JSON; preserves unrelated top-level keys + unrelated `mcpServers` entries.
- ✅ `--force` required to overwrite an existing `mindkeep` entry (exit 2 otherwise).
- ✅ Backup written to `<path>.bak` before atomic write (tmp + rename); no `.bak` on the refusal path.
- ✅ `--dry-run` prints would-be merged content; disk untouched.
- ✅ JSONC (`//` or `/*`) refused with stderr pointing at snippet mode; file untouched.
- ✅ `continue-mcp` always stdout regardless of `--out`.
- ✅ `mindkeep integrate --help` lists all 7 targets with one-line descriptions.

## Decisions made

- **`--out` semantics** — kept `--out PATH` (always requires a value). No `--in-place` flag was added in this PR; the OS-specific defaults from `_integrations.default_config_path` are exposed as a helper but not yet wired to a `--in-place` shortcut. Rationale: the canonical paths are documented in §12 and `--out "" ` style invocations stay explicit; `--in-place` can be added later without breaking the contract.
- **JSONC handling** — refuse with exit 2 + stderr hint pointing to snippet-to-stdout. Heuristic strips JSON string literals first so `"https://"` inside values doesn't false-positive.
- **Non-project cwd** — emit a stderr warning ("no .mindkeep/ directory; baking it anyway") but still bake the cwd. DESIGN §8.6 wasn't explicit; refusing felt too aggressive when users may legitimately want to integrate before `mindkeep init`.
- **`--force` without `--out`** — no-op with a stderr warning (snippet mode never writes).

## Diff

3 files changed, +768 / -13:
- `src/mindkeep/_integrations.py`: +262 lines (snippet builders, JSON merge helpers, JSONC detector, atomic write + backup)
- `src/mindkeep/cli.py`: +166 lines (`_cmd_integrate_mcp` dispatch, expanded argparse with `--dry-run` / `--project-dir`)
- `tests/test_integrate.py`: +353 lines (23 new tests covering all behaviors above + regression guard for markdown targets)

## Tests

`362 passed, 1 skipped` (the skip is pre-existing — opt-in MCP e2e). 23 new tests; no existing regressions.

## Coordination

No overlap with #36's worktree (`feat/v040-mcp-pin-resources`) — this PR touches no files under `src/mindkeep/mcp/`.

Closes #37
