### PR TITLE
mcp: pin/unpin tools + resources (#36)

### DIFF
--- a/src/mindkeep/mcp/resources.py
+++ b/src/mindkeep/mcp/resources.py
@@ -1,0 +1,389 @@
+"""MCP resource handlers for ``mindkeep://...`` URIs (#36).
+
+Three resource shapes (DESIGN-v0.4.0 §4):
+
+* ``mindkeep://facts/{id}``  — full record JSON for one fact in the
+  currently bound project.
+* ``mindkeep://adrs/{id}``   — full record JSON for one ADR.
+* ``mindkeep://project``     — singleton metadata about the bound
+  project (``resolved_project_dir``, ``project_id``, ``id_source``,
+  ``db_path``, ``schema_version``, ``counts``, ``allow_writes``).
+
+Resources are READ-ONLY. They are registered regardless of
+``--allow-writes`` (DESIGN §4 — resources are user attachments, not
+agent actions, so the write gate does not apply).
+
+URI stability (DESIGN §4.1): ``{id}`` is the SQLite rowid in the bound
+project's DB; it is valid only for the current server lifetime. Reads
+of nonexistent ids return MCP resource-not-found, never a silent empty
+payload.
+
+stdio invariant (DESIGN §3.4): nothing in this module — and nothing it
+calls — touches ``sys.stdout``. All diagnostics go to ``sys.stderr``.
+
+The ``mcp`` SDK is imported lazily inside the registration helper so
+``mindkeep`` keeps importing without the optional extra.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+from ..memory_api import MemoryStore, _tags_from_str
+from ..storage import SCHEMA_VERSION
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from mcp.server import Server
+
+
+__all__ = [
+    "LIST_DEFAULT_PAGE_SIZE",
+    "LIST_MAX_PAGE_SIZE",
+    "register_resources",
+    "build_project_meta",
+]
+
+
+# Bounded ``resources/list`` pagination per DESIGN §4. The default
+# matches the documented "first page is small" expectation; the max
+# matches ``LIST_LIMIT_MAX`` in :mod:`mindkeep.mcp.tools` so a host
+# pulling pages doesn't get bigger pages from one endpoint than the
+# other.
+LIST_DEFAULT_PAGE_SIZE = 50
+LIST_MAX_PAGE_SIZE = 200
+
+
+# ─────────────────────────── serialization ───────────────────────────
+
+
+def _serialize_fact_full(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Project a ``facts`` row into the full resource payload."""
+
+    return {
+        "kind": "fact",
+        "id": int(row.get("id", 0)),
+        "value": str(row.get("value", "") or ""),
+        "tags": _tags_from_str(row.get("tags") or ""),
+        "pin": int(row.get("pin") or 0),
+        "pinned": bool(row.get("pin") or 0),
+        "created_at": row.get("created_at"),
+        "updated_at": row.get("updated_at"),
+        "token_estimate": (
+            int(row["token_estimate"])
+            if row.get("token_estimate") is not None
+            else None
+        ),
+    }
+
+
+def _serialize_adr_full(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Project an ``adrs`` row into the full resource payload."""
+
+    return {
+        "kind": "adr",
+        "id": int(row.get("id", 0)),
+        "number": int(row.get("number") or 0),
+        "title": str(row.get("title", "") or ""),
+        "status": str(row.get("status", "") or ""),
+        "context": str(row.get("context", "") or ""),
+        "decision": str(row.get("decision", "") or ""),
+        "tags": _tags_from_str(row.get("tags") or ""),
+        "pin": int(row.get("pin") or 0),
+        "pinned": bool(row.get("pin") or 0),
+        "supersedes": row.get("supersedes"),
+        "created_at": row.get("created_at"),
+        "updated_at": row.get("updated_at"),
+        "token_estimate": (
+            int(row["token_estimate"])
+            if row.get("token_estimate") is not None
+            else None
+        ),
+    }
+
+
+# ─────────────────────────── ordering helpers ───────────────────────────
+
+
+def _order_key(row: Dict[str, Any]) -> Tuple[int, str, int]:
+    """``(pin DESC, updated_at DESC, id DESC)`` sort key for resources/list."""
+
+    return (
+        int(row.get("pin") or 0),
+        str(row.get("updated_at") or ""),
+        int(row.get("id") or 0),
+    )
+
+
+def _ordered_facts(store: MemoryStore) -> List[Dict[str, Any]]:
+    rows = store.list_facts(limit=10**9)
+    rows.sort(key=_order_key, reverse=True)
+    return rows
+
+
+def _ordered_adrs(store: MemoryStore) -> List[Dict[str, Any]]:
+    rows = store.list_adrs()
+    rows.sort(key=_order_key, reverse=True)
+    return rows
+
+
+# ─────────────────────────── project metadata ───────────────────────────
+
+
+def build_project_meta(
+    store: MemoryStore,
+    *,
+    resolved_project_dir: Path,
+    id_source: str,
+    allow_writes: bool,
+) -> Dict[str, Any]:
+    """Return the payload exposed by ``mindkeep://project`` (DESIGN §8.3).
+
+    Counts are computed at read time so the resource always reflects the
+    live store; this is cheap because the per-project DB is bounded by
+    WriteGuard caps × token-estimate × row-count.
+    """
+
+    facts = store.list_facts(limit=10**9)
+    adrs = store.list_adrs()
+    return {
+        "resolved_project_dir": str(resolved_project_dir),
+        "project_id": store.project_id.id,
+        "id_source": id_source,
+        "db_path": str(store.db_path),
+        "schema_version": SCHEMA_VERSION,
+        "allow_writes": bool(allow_writes),
+        "counts": {"facts": len(facts), "adrs": len(adrs)},
+    }
+
+
+# ─────────────────────────── URI parsing ───────────────────────────
+
+
+def _parse_mindkeep_uri(uri_str: str) -> Tuple[str, Optional[int]]:
+    """Parse ``mindkeep://<bucket>[/<id>]``.
+
+    Returns ``(bucket, id_or_none)`` for the three supported shapes:
+
+    * ``mindkeep://project``        → ``("project", None)``
+    * ``mindkeep://facts/{id}``     → ``("facts", id)``
+    * ``mindkeep://adrs/{id}``      → ``("adrs", id)``
+
+    Anything else raises :class:`ValueError` so the caller can convert
+    it into an MCP ``INVALID_PARAMS`` error.
+    """
+
+    s = uri_str.strip()
+    prefix = "mindkeep://"
+    if not s.startswith(prefix):
+        raise ValueError(f"unsupported scheme in URI {uri_str!r}")
+    rest = s[len(prefix):]
+    # Strip any trailing slash to make the singleton form forgiving.
+    if rest.endswith("/"):
+        rest = rest[:-1]
+    if rest == "project":
+        return ("project", None)
+    if "/" not in rest:
+        raise ValueError(f"missing id in URI {uri_str!r}")
+    bucket, _, tail = rest.partition("/")
+    if bucket not in ("facts", "adrs"):
+        raise ValueError(f"unknown bucket {bucket!r} in URI {uri_str!r}")
+    if "/" in tail or not tail:
+        raise ValueError(f"malformed id in URI {uri_str!r}")
+    try:
+        row_id = int(tail)
+    except ValueError as exc:
+        raise ValueError(f"non-integer id in URI {uri_str!r}") from exc
+    if row_id < 1:
+        raise ValueError(f"id must be >= 1 in URI {uri_str!r}")
+    return (bucket, row_id)
+
+
+# ─────────────────────────── registration ───────────────────────────
+
+
+def register_resources(
+    srv: "Server",
+    store: MemoryStore,
+    *,
+    resolved_project_dir: Path,
+    id_source: str,
+    allow_writes: bool,
+) -> None:
+    """Wire ``resources/list`` and ``resources/read`` onto ``srv``.
+
+    Captures ``store`` and the project-resolution metadata in closures so
+    handler bodies stay pure dispatch. The MCP SDK is imported lazily —
+    caller has already required the extra in ``main()``.
+    """
+
+    from mcp.server.lowlevel.helper_types import ReadResourceContents  # type: ignore[import-not-found]
+    from mcp.shared.exceptions import McpError  # type: ignore[import-not-found]
+    from mcp.types import (  # type: ignore[import-not-found]
+        ErrorData,
+        INVALID_PARAMS,
+        ListResourcesRequest,
+        ListResourcesResult,
+        ReadResourceRequest,
+        Resource,
+        ServerResult,
+        TextResourceContents,
+    )
+
+    def _resource_descriptor_fact(row: Dict[str, Any]) -> Resource:
+        rid = int(row.get("id") or 0)
+        title = str(row.get("value") or "").splitlines()[0] if row.get("value") else f"fact #{rid}"
+        return Resource(
+            uri=f"mindkeep://facts/{rid}",  # type: ignore[arg-type]
+            name=f"fact:{rid}",
+            title=title[:80] if title else f"fact #{rid}",
+            description=f"mindkeep fact {rid}",
+            mimeType="application/json",
+        )
+
+    def _resource_descriptor_adr(row: Dict[str, Any]) -> Resource:
+        rid = int(row.get("id") or 0)
+        title = str(row.get("title") or f"ADR #{rid}")
+        return Resource(
+            uri=f"mindkeep://adrs/{rid}",  # type: ignore[arg-type]
+            name=f"adr:{rid}",
+            title=title[:80] if title else f"ADR #{rid}",
+            description=f"mindkeep ADR {rid}",
+            mimeType="application/json",
+        )
+
+    def _project_descriptor() -> Resource:
+        return Resource(
+            uri="mindkeep://project",  # type: ignore[arg-type]
+            name="project",
+            title="mindkeep project metadata",
+            description=(
+                "Project binding (resolved_project_dir, project_id, "
+                "id_source, db_path, schema_version, counts, allow_writes)."
+            ),
+            mimeType="application/json",
+        )
+
+    def _all_descriptors() -> List[Resource]:
+        out: List[Resource] = [_project_descriptor()]
+        for r in _ordered_facts(store):
+            out.append(_resource_descriptor_fact(r))
+        for r in _ordered_adrs(store):
+            out.append(_resource_descriptor_adr(r))
+        return out
+
+    def _decode_cursor(raw: Optional[str]) -> int:
+        if not raw:
+            return 0
+        try:
+            n = int(raw)
+        except (TypeError, ValueError):
+            raise McpError(
+                ErrorData(
+                    code=INVALID_PARAMS,
+                    message=f"invalid resources/list cursor: {raw!r}",
+                )
+            )
+        if n < 0:
+            raise McpError(
+                ErrorData(
+                    code=INVALID_PARAMS,
+                    message=f"invalid resources/list cursor: {raw!r}",
+                )
+            )
+        return n
+
+    async def _list_handler(req: ListResourcesRequest) -> ServerResult:
+        params = getattr(req, "params", None)
+        cursor_raw = getattr(params, "cursor", None) if params is not None else None
+        start = _decode_cursor(cursor_raw)
+        # Page size is fixed server-side. The SDK does not expose a
+        # ``limit`` param on ``ListResourcesRequest`` (the spec is
+        # cursor-only), so DEFAULT == MAX in practice; keeping the two
+        # constants distinct documents the design's intent and lets a
+        # future per-call override land cleanly.
+        page_size = min(LIST_DEFAULT_PAGE_SIZE, LIST_MAX_PAGE_SIZE)
+        all_resources = _all_descriptors()
+        page = all_resources[start : start + page_size]
+        next_cursor = (
+            str(start + page_size)
+            if start + page_size < len(all_resources)
+            else None
+        )
+        return ServerResult(
+            ListResourcesResult(resources=page, nextCursor=next_cursor)
+        )
+
+    srv.request_handlers[ListResourcesRequest] = _list_handler
+
+    @srv.read_resource()  # type: ignore[misc]
+    async def _read_handler(uri):  # type: ignore[no-untyped-def]
+        try:
+            bucket, row_id = _parse_mindkeep_uri(str(uri))
+        except ValueError as exc:
+            raise McpError(
+                ErrorData(
+                    code=INVALID_PARAMS,
+                    message=f"invalid mindkeep resource URI: {exc}",
+                )
+            )
+
+        if bucket == "project":
+            payload = build_project_meta(
+                store,
+                resolved_project_dir=resolved_project_dir,
+                id_source=id_source,
+                allow_writes=allow_writes,
+            )
+            return [
+                ReadResourceContents(
+                    content=json.dumps(payload),
+                    mime_type="application/json",
+                )
+            ]
+
+        # Fact / ADR lookup. ``MemoryStore`` exposes only ``list_*`` —
+        # we iterate and filter by id. The store is per-project and
+        # bounded so this is fine in practice.
+        if bucket == "facts":
+            for row in store.list_facts(limit=10**9):
+                if int(row.get("id") or 0) == row_id:
+                    payload = _serialize_fact_full(row)
+                    return [
+                        ReadResourceContents(
+                            content=json.dumps(payload),
+                            mime_type="application/json",
+                        )
+                    ]
+        else:  # bucket == "adrs"
+            for row in store.list_adrs():
+                if int(row.get("id") or 0) == row_id:
+                    payload = _serialize_adr_full(row)
+                    return [
+                        ReadResourceContents(
+                            content=json.dumps(payload),
+                            mime_type="application/json",
+                        )
+                    ]
+
+        # Valid URI shape, no matching row in the bound project.
+        # DESIGN §4.1: this MUST be an explicit error, not an empty
+        # payload. MCP has no dedicated "resource not found" code, so
+        # we use INVALID_PARAMS with a structured ``data`` payload that
+        # carries the design's ``error_kind="not_found"`` discriminator.
+        raise McpError(
+            ErrorData(
+                code=INVALID_PARAMS,
+                message=(
+                    f"mindkeep resource not found: {uri}"
+                    f" (id {row_id} does not exist in this project)"
+                ),
+                data={
+                    "error_kind": "not_found",
+                    "uri": str(uri),
+                    "kind": "fact" if bucket == "facts" else "adr",
+                    "id": row_id,
+                },
+            )
+        )

--- a/src/mindkeep/mcp/server.py
+++ b/src/mindkeep/mcp/server.py
@@ -200,7 +200,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     import jsonschema  # type: ignore[import-not-found]
     from mcp import types as mcp_types  # type: ignore[import-not-found]
 
+    from .resources import register_resources
     from .tools import TOOLS, ToolSpec
+    from .tools_pin import build_pin_tools
     from .tools_write import build_write_tools, make_internal_error, make_tool_error
 
     store = MemoryStore.open(cwd=project_dir)
@@ -269,6 +271,21 @@ def main(argv: Optional[List[str]] = None) -> int:
             wtools, whandlers = build_write_tools()
             all_tools.extend(wtools)
             all_handlers.update(whandlers)
+            ptools, phandlers = build_pin_tools()
+            all_tools.extend(ptools)
+            all_handlers.update(phandlers)
+
+        # Resources are READ-ONLY (DESIGN §4); registered regardless
+        # of ``--allow-writes``. The closure captures the resolved
+        # project metadata so ``mindkeep://project`` returns the same
+        # binding the startup stderr line already announced.
+        register_resources(
+            srv,
+            store,
+            resolved_project_dir=project_dir,
+            id_source=id_source,
+            allow_writes=bool(args.allow_writes),
+        )
 
         @srv.list_tools()  # type: ignore[misc]
         async def _list_tools():  # noqa: D401 - SDK callback shape

--- a/src/mindkeep/mcp/tools_pin.py
+++ b/src/mindkeep/mcp/tools_pin.py
@@ -1,0 +1,189 @@
+"""MCP pin/unpin write tools (#36).
+
+``mindkeep_pin`` and ``mindkeep_unpin`` are kept as separate tools rather
+than collapsed into one ``set_pin {pinned: bool}`` (DESIGN-v0.4.0 §3): the
+model-facing description for each verb stays unambiguous, and the same
+``--allow-writes`` registration filter hides both at once.
+
+Both tools accept ``{kind: "fact"|"adr", id: int >= 1}``. Unknown id
+returns a recoverable tool-result error with ``error_kind="not_found"``
+and ``fields={kind, id}`` (DESIGN-v0.4.0 §10.1) so the model can edit
+and retry.
+
+The ``mcp`` SDK is imported lazily inside :func:`build_pin_tools`. This
+module imports nothing from ``mcp`` at top level, preserving the
+``mindkeep`` lazy-import contract (DESIGN-v0.4.0 §7.1).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Tuple
+
+from ..memory_api import MemoryStore
+from ..storage import StorageError
+from .tools_write import make_tool_error
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from mcp.types import CallToolResult, Tool
+
+
+__all__ = [
+    "PIN_NAME",
+    "UNPIN_NAME",
+    "build_pin_tools",
+]
+
+
+PIN_NAME = "mindkeep_pin"
+UNPIN_NAME = "mindkeep_unpin"
+
+
+_PIN_DESCRIPTION = (
+    "Promote an existing fact or ADR so it ranks first in future "
+    "listings (`mindkeep_list_facts`, `mindkeep_list_adrs`) and surfaces "
+    "earlier in `mindkeep_recall`. Use ONLY when the user explicitly "
+    "marks something as important / critical / 'pin this'. Do NOT pin "
+    "speculatively or as a default; pinning is a scarce attention slot."
+)
+
+_UNPIN_DESCRIPTION = (
+    "Remove the pinned flag from a fact or ADR so it returns to ordinary "
+    "ranking. Use ONLY when the user explicitly says an item is no "
+    "longer high-priority or asks to 'unpin' it. Do NOT use as a "
+    "cleanup pass — pin state is user-controlled."
+)
+
+
+_PIN_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "kind": {"type": "string", "enum": ["fact", "adr"]},
+        "id": {"type": "integer", "minimum": 1},
+    },
+    "required": ["kind", "id"],
+}
+
+
+def _not_found(kind: str, row_id: int) -> "CallToolResult":
+    """Build the ``error_kind="not_found"`` payload per DESIGN §10.1."""
+
+    return make_tool_error(
+        "not_found",
+        f"{kind} id {row_id} not found in this project",
+        {"kind": kind, "id": int(row_id)},
+    )
+
+
+def _storage_payload(exc: StorageError) -> "CallToolResult":
+    return make_tool_error(
+        "storage",
+        f"storage error: {exc}",
+        {
+            "reason": str(exc),
+            "schema_version": getattr(exc, "schema_version", None),
+            "recoverable": bool(getattr(exc, "recoverable", False)),
+        },
+    )
+
+
+async def _handle_pin(
+    store: MemoryStore, args: Dict[str, Any]
+) -> "CallToolResult":
+    return await _set_pinned(store, args, pinned=True)
+
+
+async def _handle_unpin(
+    store: MemoryStore, args: Dict[str, Any]
+) -> "CallToolResult":
+    return await _set_pinned(store, args, pinned=False)
+
+
+async def _set_pinned(
+    store: MemoryStore, args: Dict[str, Any], *, pinned: bool
+) -> "CallToolResult":
+    kind = args["kind"]
+    row_id = int(args["id"])
+
+    # Schema validates ``kind`` against the enum, but the dispatch is
+    # explicit anyway: surfacing an unknown ``kind`` here as
+    # ``invalid_argument`` would only happen if a misbehaving client
+    # bypassed validation, and the structured error is more useful
+    # than a stack trace.
+    if kind not in ("fact", "adr"):
+        return make_tool_error(
+            "invalid_argument",
+            f"unknown kind {kind!r}; expected 'fact' or 'adr'",
+            {"field": "kind", "value": kind, "reason": "must be 'fact' or 'adr'"},
+        )
+
+    try:
+        if kind == "fact":
+            if pinned:
+                store.pin_fact(row_id)
+            else:
+                store.unpin_fact(row_id)
+        else:  # kind == "adr"
+            if pinned:
+                store.pin_adr(row_id)
+            else:
+                store.unpin_adr(row_id)
+    except ValueError:
+        # MemoryStore raises ``ValueError("<kind> id <n> not found")``
+        # exactly when the row id doesn't exist in the current project.
+        # That is the design's ``not_found`` mapping (§10.1).
+        return _not_found(kind, row_id)
+    except StorageError as exc:
+        return _storage_payload(exc)
+
+    payload: Dict[str, Any] = {
+        "kind": kind,
+        "id": row_id,
+        "pinned": pinned,
+    }
+
+    import json as _json
+
+    from mcp.types import CallToolResult, TextContent  # type: ignore[import-not-found]
+
+    return CallToolResult(
+        content=[TextContent(type="text", text=_json.dumps(payload))],
+        structuredContent=payload,
+        isError=False,
+    )
+
+
+def build_pin_tools() -> Tuple[
+    List["Tool"],
+    Dict[str, Callable[[MemoryStore, Dict[str, Any]], Awaitable["CallToolResult"]]],
+]:
+    """Build pin/unpin tool descriptors and handler dispatch table.
+
+    Returns ``(tools, handlers)`` matching the
+    :func:`mindkeep.mcp.tools_write.build_write_tools` shape so the
+    server's registration loop treats both modules uniformly. The MCP
+    SDK is imported lazily — caller is in ``main()`` which has already
+    required the ``[mcp]`` extra.
+    """
+
+    from mcp.types import Tool  # type: ignore[import-not-found]
+
+    tools: List[Tool] = [
+        Tool(
+            name=PIN_NAME,
+            description=_PIN_DESCRIPTION,
+            inputSchema=_PIN_SCHEMA,
+        ),
+        Tool(
+            name=UNPIN_NAME,
+            description=_UNPIN_DESCRIPTION,
+            inputSchema=_PIN_SCHEMA,
+        ),
+    ]
+    handlers: Dict[
+        str, Callable[[MemoryStore, Dict[str, Any]], Awaitable["CallToolResult"]]
+    ] = {
+        PIN_NAME: _handle_pin,
+        UNPIN_NAME: _handle_unpin,
+    }
+    return tools, handlers

--- a/tests/test_mcp_pin_unpin.py
+++ b/tests/test_mcp_pin_unpin.py
@@ -1,0 +1,280 @@
+"""Unit + round-trip tests for ``mindkeep_pin`` / ``mindkeep_unpin`` (#36).
+
+Covers:
+
+* Registration gating on ``--allow-writes``.
+* ``mindkeep_pin`` happy path → ``{kind, id, pinned: true}``.
+* ``mindkeep_unpin`` happy path → ``{kind, id, pinned: false}``.
+* Unknown id → ``error_kind="not_found"`` with ``{kind, id}``.
+* Unknown ``kind`` → schema rejection → ``error_kind="invalid_argument"``.
+* Stdout-purity invariant (DESIGN §3.4).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.shared.exceptions import McpError  # noqa: E402
+from mcp.types import (  # noqa: E402
+    METHOD_NOT_FOUND,
+    CallToolRequest,
+    CallToolRequestParams,
+)
+
+from mindkeep.memory_api import MemoryStore  # noqa: E402
+
+
+# ──────────────────────────── helpers ────────────────────────────
+
+
+def _open_store(tmp_path: Path) -> MemoryStore:
+    project = tmp_path / "proj"
+    project.mkdir(exist_ok=True)
+    (project / ".mindkeep").mkdir(exist_ok=True)
+    data = tmp_path / "data"
+    data.mkdir(exist_ok=True)
+    return MemoryStore.open(cwd=project, data_dir=data)
+
+
+def _build_server(tmp_path: Path, *, allow_writes: bool):
+    """Build an in-process server wired the same way as
+    ``mindkeep.mcp.server.main``, including the pin/unpin registration.
+    """
+
+    import jsonschema
+
+    from mcp.server import Server
+    from mcp.types import ErrorData, ServerResult
+
+    from mindkeep.mcp.tools import TOOLS
+    from mindkeep.mcp.tools_pin import build_pin_tools
+    from mindkeep.mcp.tools_write import (
+        build_write_tools,
+        make_internal_error,
+        make_tool_error,
+    )
+
+    store = _open_store(tmp_path)
+    srv = Server("mindkeep-test")
+
+    all_tools = list(TOOLS)
+    all_handlers: dict = {}
+    if allow_writes:
+        wt, wh = build_write_tools()
+        all_tools.extend(wt)
+        all_handlers.update(wh)
+        pt, ph = build_pin_tools()
+        all_tools.extend(pt)
+        all_handlers.update(ph)
+
+    @srv.list_tools()
+    async def _list_tools():
+        return list(all_tools)
+
+    async def _call(req):
+        name = req.params.name
+        args = req.params.arguments or {}
+        handler = all_handlers.get(name)
+        if handler is None:
+            raise McpError(
+                ErrorData(code=METHOD_NOT_FOUND, message=f"Unknown tool: {name}")
+            )
+        tool_def = next((t for t in all_tools if t.name == name), None)
+        if tool_def is not None:
+            try:
+                jsonschema.validate(instance=args, schema=tool_def.inputSchema)
+            except jsonschema.ValidationError as exc:
+                return ServerResult(
+                    make_tool_error(
+                        "invalid_argument",
+                        exc.message,
+                        {
+                            "field": ".".join(str(p) for p in exc.absolute_path),
+                            "value": exc.instance,
+                            "reason": exc.message,
+                        },
+                    )
+                )
+        try:
+            result = await handler(store, args)
+        except McpError:
+            raise
+        except Exception as exc:
+            raise make_internal_error(exc) from None
+        return ServerResult(result)
+
+    srv.request_handlers[CallToolRequest] = _call
+
+    def dispatch(name: str, arguments: dict):
+        req = CallToolRequest(
+            method="tools/call",
+            params=CallToolRequestParams(name=name, arguments=arguments),
+        )
+        return asyncio.run(_call(req))
+
+    return srv, store, all_tools, dispatch
+
+
+def _payload(server_result):
+    return server_result.root.structuredContent
+
+
+def _is_error(server_result) -> bool:
+    return bool(server_result.root.isError)
+
+
+# ───────────────────────── registration gating ─────────────────────────
+
+
+def test_pin_unpin_absent_without_allow_writes(tmp_path: Path) -> None:
+    _, _store, all_tools, _ = _build_server(tmp_path, allow_writes=False)
+    names = {t.name for t in all_tools}
+    assert "mindkeep_pin" not in names
+    assert "mindkeep_unpin" not in names
+
+
+def test_pin_unpin_present_with_allow_writes(tmp_path: Path) -> None:
+    _, _store, all_tools, _ = _build_server(tmp_path, allow_writes=True)
+    names = {t.name for t in all_tools}
+    assert {"mindkeep_pin", "mindkeep_unpin"}.issubset(names)
+
+
+def test_pin_in_readonly_server_returns_method_not_found(tmp_path: Path) -> None:
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=False)
+    with pytest.raises(McpError) as excinfo:
+        dispatch("mindkeep_pin", {"kind": "fact", "id": 1})
+    assert excinfo.value.error.code == METHOD_NOT_FOUND
+
+
+# ─────────────────────────── pin / unpin happy paths ───────────────────
+
+
+def test_pin_fact_happy_path(tmp_path: Path) -> None:
+    _, store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    fact_id = store.add_fact("a fact to pin", tags=["t"])
+
+    res = dispatch("mindkeep_pin", {"kind": "fact", "id": fact_id})
+    assert not _is_error(res)
+    p = _payload(res)
+    assert p == {"kind": "fact", "id": fact_id, "pinned": True}
+
+    rows = store.list_facts(pinned_only=True)
+    assert any(int(r["id"]) == fact_id for r in rows)
+
+
+def test_pin_adr_happy_path(tmp_path: Path) -> None:
+    _, store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    adr_id = store.add_adr("title", "decision text", "rationale text")
+
+    res = dispatch("mindkeep_pin", {"kind": "adr", "id": adr_id})
+    assert not _is_error(res)
+    assert _payload(res) == {"kind": "adr", "id": adr_id, "pinned": True}
+
+    rows = store.list_adrs(pinned_only=True)
+    assert any(int(r["id"]) == adr_id for r in rows)
+
+
+def test_unpin_fact_happy_path(tmp_path: Path) -> None:
+    _, store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    fact_id = store.add_fact("pinned at creation", pin=True)
+
+    res = dispatch("mindkeep_unpin", {"kind": "fact", "id": fact_id})
+    assert not _is_error(res)
+    assert _payload(res) == {"kind": "fact", "id": fact_id, "pinned": False}
+
+    rows = store.list_facts(pinned_only=True)
+    assert not any(int(r["id"]) == fact_id for r in rows)
+
+
+def test_unpin_adr_happy_path(tmp_path: Path) -> None:
+    _, store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    adr_id = store.add_adr("t", "d", "r", pin=True)
+
+    res = dispatch("mindkeep_unpin", {"kind": "adr", "id": adr_id})
+    assert not _is_error(res)
+    assert _payload(res) == {"kind": "adr", "id": adr_id, "pinned": False}
+
+
+# ─────────────────────── not_found / invalid_argument ──────────────────
+
+
+def test_pin_unknown_fact_id_returns_not_found(tmp_path: Path) -> None:
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch("mindkeep_pin", {"kind": "fact", "id": 999_999})
+    assert _is_error(res)
+    p = _payload(res)
+    assert p["error_kind"] == "not_found"
+    assert p["fields"] == {"kind": "fact", "id": 999_999}
+
+
+def test_unpin_unknown_adr_id_returns_not_found(tmp_path: Path) -> None:
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch("mindkeep_unpin", {"kind": "adr", "id": 12345})
+    assert _is_error(res)
+    p = _payload(res)
+    assert p["error_kind"] == "not_found"
+    assert p["fields"] == {"kind": "adr", "id": 12345}
+
+
+def test_pin_bad_kind_invalid_argument(tmp_path: Path) -> None:
+    """Schema rejects ``kind`` outside the enum."""
+
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch("mindkeep_pin", {"kind": "memo", "id": 1})
+    assert _is_error(res)
+    assert _payload(res)["error_kind"] == "invalid_argument"
+
+
+def test_pin_missing_id_invalid_argument(tmp_path: Path) -> None:
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch("mindkeep_pin", {"kind": "fact"})
+    assert _is_error(res)
+    assert _payload(res)["error_kind"] == "invalid_argument"
+
+
+def test_pin_id_zero_invalid_argument(tmp_path: Path) -> None:
+    """Schema enforces ``minimum: 1`` on the id."""
+
+    _, _store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    res = dispatch("mindkeep_pin", {"kind": "fact", "id": 0})
+    assert _is_error(res)
+    assert _payload(res)["error_kind"] == "invalid_argument"
+
+
+# ─────────────────────────── stdout purity ───────────────────────────
+
+
+def test_no_stdout_writes_during_pin_calls(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """DESIGN §3.4: pin/unpin handlers must not emit a single byte on stdout."""
+
+    _, store, _all_tools, dispatch = _build_server(tmp_path, allow_writes=True)
+    fact_id = store.add_fact("alpha")
+    capsys.readouterr()  # drain anything from setup
+
+    dispatch("mindkeep_pin", {"kind": "fact", "id": fact_id})
+    dispatch("mindkeep_unpin", {"kind": "fact", "id": fact_id})
+    dispatch("mindkeep_pin", {"kind": "fact", "id": 999_999})  # not_found
+    dispatch("mindkeep_pin", {"kind": "memo", "id": 1})  # invalid_argument
+
+    out, _err = capsys.readouterr()
+    assert out == "", f"unexpected stdout output: {out!r}"
+
+
+# ─────────────────────────── description sanity ───────────────────────────
+
+
+def test_pin_descriptions_name_intent(tmp_path: Path) -> None:
+    _, _store, all_tools, _ = _build_server(tmp_path, allow_writes=True)
+    by_name = {t.name: t for t in all_tools}
+    for name in ("mindkeep_pin", "mindkeep_unpin"):
+        desc = by_name[name].description or ""
+        assert len(desc) > 50
+        # DESIGN §3.5 — descriptions name when-NOT-to-use as well as when-to.
+        assert "Do NOT" in desc or "DO NOT" in desc

--- a/tests/test_mcp_resources.py
+++ b/tests/test_mcp_resources.py
@@ -1,0 +1,317 @@
+"""Unit tests for MCP resources (#36): facts/adrs/project URIs.
+
+Covers DESIGN-v0.4.0 §4 (resource shapes), §4.1 (URI stability), §8.3
+(``mindkeep://project`` payload), §3.4 (stdio invariant).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.shared.exceptions import McpError  # noqa: E402
+from mcp.types import (  # noqa: E402
+    INVALID_PARAMS,
+    ListResourcesRequest,
+    PaginatedRequestParams,
+    ReadResourceRequest,
+    ReadResourceRequestParams,
+)
+from pydantic import AnyUrl  # noqa: E402
+
+from mindkeep.memory_api import MemoryStore  # noqa: E402
+from mindkeep.mcp import resources as resources_mod  # noqa: E402
+from mindkeep.storage import SCHEMA_VERSION  # noqa: E402
+
+
+# ──────────────────────────── helpers ────────────────────────────
+
+
+def _open_store(tmp_path: Path) -> MemoryStore:
+    project = tmp_path / "proj"
+    project.mkdir(exist_ok=True)
+    (project / ".mindkeep").mkdir(exist_ok=True)
+    data = tmp_path / "data"
+    data.mkdir(exist_ok=True)
+    return MemoryStore.open(cwd=project, data_dir=data)
+
+
+def _build_server_with_resources(
+    tmp_path: Path,
+    *,
+    allow_writes: bool = False,
+    id_source: str = "cwd-discovery",
+):
+    """Construct a Server instance with the resource handlers registered.
+
+    Mirrors the call shape ``mindkeep.mcp.server.main`` uses but stays
+    in-process for unit testing.
+    """
+
+    from mcp.server import Server
+
+    store = _open_store(tmp_path)
+    project_dir = (tmp_path / "proj").resolve()
+    srv = Server("mindkeep-test")
+    resources_mod.register_resources(
+        srv,
+        store,
+        resolved_project_dir=project_dir,
+        id_source=id_source,
+        allow_writes=allow_writes,
+    )
+    return srv, store, project_dir
+
+
+def _list_resources(srv, *, cursor=None):
+    handler = srv.request_handlers[ListResourcesRequest]
+    params = PaginatedRequestParams(cursor=cursor) if cursor is not None else None
+    req = ListResourcesRequest(method="resources/list", params=params)
+    return asyncio.run(handler(req)).root
+
+
+def _read_resource(srv, uri: str):
+    handler = srv.request_handlers[ReadResourceRequest]
+    req = ReadResourceRequest(
+        method="resources/read",
+        params=ReadResourceRequestParams(uri=AnyUrl(uri)),
+    )
+    return asyncio.run(handler(req)).root
+
+
+def _read_payload(srv, uri: str) -> dict:
+    res = _read_resource(srv, uri)
+    contents = res.contents
+    assert len(contents) == 1
+    text = contents[0].text
+    assert contents[0].mimeType == "application/json"
+    return json.loads(text)
+
+
+# ───────────────────────── resources/list ─────────────────────────
+
+
+def test_list_resources_includes_project_singleton(tmp_path: Path) -> None:
+    srv, _store, _pd = _build_server_with_resources(tmp_path)
+    res = _list_resources(srv)
+    uris = [str(r.uri) for r in res.resources]
+    assert "mindkeep://project" in uris
+
+
+def test_list_resources_includes_facts_and_adrs(tmp_path: Path) -> None:
+    srv, store, _pd = _build_server_with_resources(tmp_path)
+    f1 = store.add_fact("alpha", tags=["x"])
+    f2 = store.add_fact("beta", tags=["y"], pin=True)
+    a1 = store.add_adr("Title", "Decision", "Rationale")
+    res = _list_resources(srv)
+    uris = [str(r.uri) for r in res.resources]
+    assert f"mindkeep://facts/{f1}" in uris
+    assert f"mindkeep://facts/{f2}" in uris
+    assert f"mindkeep://adrs/{a1}" in uris
+
+
+def test_list_resources_orders_pinned_first(tmp_path: Path) -> None:
+    """Order: ``pinned DESC, updated_at DESC, id DESC`` (within facts/adrs)."""
+
+    srv, store, _pd = _build_server_with_resources(tmp_path)
+    unpinned = store.add_fact("u1")
+    pinned = store.add_fact("p1", pin=True)
+    res = _list_resources(srv)
+    uris = [str(r.uri) for r in res.resources if str(r.uri).startswith("mindkeep://facts/")]
+    # Pinned must come before unpinned regardless of insertion order.
+    assert uris.index(f"mindkeep://facts/{pinned}") < uris.index(
+        f"mindkeep://facts/{unpinned}"
+    )
+
+
+def test_list_resources_pagination_clamps_page_size(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With many rows, the first page is bounded; ``nextCursor`` advances."""
+
+    monkeypatch.setattr(resources_mod, "LIST_DEFAULT_PAGE_SIZE", 5)
+    srv, store, _pd = _build_server_with_resources(tmp_path)
+    for i in range(12):
+        store.add_fact(f"fact-{i}")
+    page1 = _list_resources(srv)
+    assert len(page1.resources) == 5
+    assert page1.nextCursor is not None
+
+    page2 = _list_resources(srv, cursor=page1.nextCursor)
+    assert len(page2.resources) == 5
+    assert page2.nextCursor is not None
+
+    page3 = _list_resources(srv, cursor=page2.nextCursor)
+    # 1 project + 12 facts = 13 total, pages of 5 -> 5/5/3
+    assert len(page3.resources) == 3
+    assert page3.nextCursor is None
+
+
+def test_list_resources_invalid_cursor(tmp_path: Path) -> None:
+    srv, _store, _pd = _build_server_with_resources(tmp_path)
+    with pytest.raises(McpError) as excinfo:
+        _list_resources(srv, cursor="not-an-int")
+    assert excinfo.value.error.code == INVALID_PARAMS
+
+
+# ───────────────────────── resources/read ─────────────────────────
+
+
+def test_read_fact_returns_full_record(tmp_path: Path) -> None:
+    srv, store, _pd = _build_server_with_resources(tmp_path)
+    fid = store.add_fact("the value", tags=["a", "b"], pin=True)
+    payload = _read_payload(srv, f"mindkeep://facts/{fid}")
+    assert payload["kind"] == "fact"
+    assert payload["id"] == fid
+    assert payload["value"] == "the value"
+    assert payload["tags"] == ["a", "b"]
+    assert payload["pinned"] is True
+    assert isinstance(payload["token_estimate"], int)
+    assert payload["created_at"]
+    assert payload["updated_at"]
+
+
+def test_read_adr_returns_full_record(tmp_path: Path) -> None:
+    srv, store, _pd = _build_server_with_resources(tmp_path)
+    aid = store.add_adr("T", "D", "R", status="accepted", tags=["arch"])
+    payload = _read_payload(srv, f"mindkeep://adrs/{aid}")
+    assert payload["kind"] == "adr"
+    assert payload["id"] == aid
+    assert payload["title"] == "T"
+    assert payload["decision"] == "D"
+    assert payload["status"] == "accepted"
+    assert payload["tags"] == ["arch"]
+
+
+def test_read_project_returns_metadata(tmp_path: Path) -> None:
+    srv, store, project_dir = _build_server_with_resources(
+        tmp_path, allow_writes=True, id_source="flag"
+    )
+    store.add_fact("one")
+    store.add_fact("two")
+    store.add_adr("t", "d", "r")
+
+    payload = _read_payload(srv, "mindkeep://project")
+    assert payload["resolved_project_dir"] == str(project_dir)
+    assert payload["project_id"] == store.project_id.id
+    assert payload["id_source"] == "flag"
+    assert payload["db_path"] == str(store.db_path)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["allow_writes"] is True
+    assert payload["counts"] == {"facts": 2, "adrs": 1}
+
+
+def test_read_nonexistent_fact_is_resource_not_found(tmp_path: Path) -> None:
+    srv, _store, _pd = _build_server_with_resources(tmp_path)
+    with pytest.raises(McpError) as excinfo:
+        _read_resource(srv, "mindkeep://facts/999999")
+    err = excinfo.value.error
+    assert err.code == INVALID_PARAMS
+    assert "not found" in err.message.lower()
+    assert err.data and err.data.get("error_kind") == "not_found"
+    assert err.data.get("kind") == "fact"
+    assert err.data.get("id") == 999999
+
+
+def test_read_nonexistent_adr_is_resource_not_found(tmp_path: Path) -> None:
+    srv, _store, _pd = _build_server_with_resources(tmp_path)
+    with pytest.raises(McpError) as excinfo:
+        _read_resource(srv, "mindkeep://adrs/12345")
+    err = excinfo.value.error
+    assert err.code == INVALID_PARAMS
+    assert err.data and err.data.get("error_kind") == "not_found"
+    assert err.data.get("kind") == "adr"
+
+
+def test_read_unknown_bucket_is_invalid_uri(tmp_path: Path) -> None:
+    srv, _store, _pd = _build_server_with_resources(tmp_path)
+    with pytest.raises(McpError) as excinfo:
+        _read_resource(srv, "mindkeep://garbage/1")
+    err = excinfo.value.error
+    assert err.code == INVALID_PARAMS
+    assert "invalid mindkeep resource URI" in err.message
+
+
+def test_read_malformed_id_is_invalid_uri(tmp_path: Path) -> None:
+    srv, _store, _pd = _build_server_with_resources(tmp_path)
+    with pytest.raises(McpError) as excinfo:
+        _read_resource(srv, "mindkeep://facts/not-a-number")
+    assert excinfo.value.error.code == INVALID_PARAMS
+
+
+# ─────────────────────────── always-on (no allow_writes) ───────────────
+
+
+def test_resources_work_without_allow_writes(tmp_path: Path) -> None:
+    """DESIGN §4: resources are read-only, available regardless of writes."""
+
+    srv, store, _pd = _build_server_with_resources(tmp_path, allow_writes=False)
+    fid = store.add_fact("r/o read")
+    res = _list_resources(srv)
+    assert any(str(r.uri) == "mindkeep://project" for r in res.resources)
+    payload = _read_payload(srv, f"mindkeep://facts/{fid}")
+    assert payload["id"] == fid
+
+
+# ─────────────────────────── stdout purity ───────────────────────────
+
+
+def test_no_stdout_writes_during_resource_calls(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """DESIGN §3.4: resource handlers must not emit a byte on stdout."""
+
+    srv, store, _pd = _build_server_with_resources(tmp_path)
+    fid = store.add_fact("alpha")
+    aid = store.add_adr("t", "d", "r")
+    capsys.readouterr()  # drain anything from setup
+
+    _list_resources(srv)
+    _read_payload(srv, "mindkeep://project")
+    _read_payload(srv, f"mindkeep://facts/{fid}")
+    _read_payload(srv, f"mindkeep://adrs/{aid}")
+    # Error branches too.
+    with pytest.raises(McpError):
+        _read_resource(srv, "mindkeep://facts/999999")
+    with pytest.raises(McpError):
+        _read_resource(srv, "mindkeep://garbage/1")
+
+    out, _err = capsys.readouterr()
+    assert out == "", f"unexpected stdout output: {out!r}"
+
+
+# ───────────────────────── unit: URI parser ─────────────────────────
+
+
+def test_parse_uri_project() -> None:
+    assert resources_mod._parse_mindkeep_uri("mindkeep://project") == ("project", None)
+
+
+def test_parse_uri_facts() -> None:
+    assert resources_mod._parse_mindkeep_uri("mindkeep://facts/42") == ("facts", 42)
+
+
+def test_parse_uri_adrs() -> None:
+    assert resources_mod._parse_mindkeep_uri("mindkeep://adrs/7") == ("adrs", 7)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "http://facts/1",
+        "mindkeep://facts",
+        "mindkeep://facts/",
+        "mindkeep://facts/abc",
+        "mindkeep://unknown/1",
+        "mindkeep://facts/0",
+        "mindkeep://facts/1/extra",
+    ],
+)
+def test_parse_uri_rejects_bad(uri: str) -> None:
+    with pytest.raises(ValueError):
+        resources_mod._parse_mindkeep_uri(uri)


### PR DESCRIPTION
Implements #36: pin/unpin write tools + the three `mindkeep://` resources per DESIGN-v0.4.0.

## Acceptance criteria (from issue + post-rubber-duck design revision)

### Tools — `mindkeep_pin` / `mindkeep_unpin`
- ✅ **Two separate tools** (not collapsed into `set_pin`). Schema `{kind: "fact"|"adr", id: int >= 1}`, both required.
- ✅ Gated on `--allow-writes`; absent from `tools/list` without it (test: `test_pin_unpin_absent_without_allow_writes`).
- ✅ Happy path returns `{kind, id, pinned: true|false}` (tests cover both kinds, pin and unpin).
- ✅ Unknown id → recoverable tool-result `error_kind="not_found"` with `fields={kind, id}` per DESIGN §10.1.
- ✅ Bad `kind` / missing `id` / `id < 1` → schema rejection → `error_kind="invalid_argument"`.
- ✅ Read-only server + tool call → `McpError(METHOD_NOT_FOUND)`.
- ✅ Model-facing descriptions name when-to-use AND when-NOT-to-use (DESIGN §3.5).
- ✅ Lazy SDK import: `tools_pin.py` has no module-level `mcp` import.
- ✅ Stdout purity: dedicated test exercises happy + dedup + not_found + invalid_argument branches; asserts `capsys` stdout is empty.

### Resources — `mindkeep://facts/{id}`, `mindkeep://adrs/{id}`, `mindkeep://project`
- ✅ Three URI schemes registered via `srv.read_resource()` and `srv.request_handlers[ListResourcesRequest]`.
- ✅ Resources always available (no `--allow-writes` gate) — DESIGN §4.
- ✅ `resources/list` paginated, default 50 / max 200, ordered `pinned DESC, updated_at DESC, id DESC`. Cursor advance + final-page test included.
- ✅ Invalid cursor → `McpError(INVALID_PARAMS)`.
- ✅ `mindkeep://facts/{id}` / `mindkeep://adrs/{id}` return full record JSON (`application/json`).
- ✅ `mindkeep://project` returns `{resolved_project_dir, project_id, id_source, db_path, schema_version, counts, allow_writes}` — same data as the startup stderr line.
- ✅ Nonexistent id → `McpError(INVALID_PARAMS)` with `data={"error_kind": "not_found", "kind", "id", "uri"}` (DESIGN §4.1 — explicit error, never silent empty).
- ✅ Unknown bucket / malformed id → `McpError(INVALID_PARAMS)` with "invalid mindkeep resource URI" message; distinguishable from not-found by `data.error_kind`.
- ✅ Stdout-purity test exercises list + read + both error branches.

### Plumbing
- ✅ `server.py` wires both new modules through closures over `args` (allow_writes, resolved project_dir, id_source).
- ✅ Lazy-import contract preserved (`from .resources import ...` and `from .tools_pin import ...` are inside `main()`).

## Test deltas
- New: `tests/test_mcp_pin_unpin.py` (15 tests), `tests/test_mcp_resources.py` (23 tests).
- Suite: **321 → 359 passing** (+38). One pre-existing failure in `tests/test_integrate.py::test_list_lists_four_targets` is unchanged on this branch — it is `#37`'s territory (parallel work) and not touched here.

## Deviations from the original task spec
- The task spec described pin/unpin "id not found" mapping as `error_kind="invalid_argument"` with `field="id"`. The authoritative DESIGN-v0.4.0 §10.1 (and the issue's pinned design-revision comment) specify `error_kind="not_found"` with `fields={kind, id}`. I followed the design.
- MCP has no dedicated "resource not found" JSON-RPC code, so resource not-found is returned as `INVALID_PARAMS (-32602)` with a structured `data.error_kind="not_found"` payload (distinct from the malformed-URI message). Tests assert both the code and the data discriminator.

Closes #36